### PR TITLE
Fixed the . and .. edge case for ADD/COPY steps

### DIFF
--- a/lib/archive/copy_op.go
+++ b/lib/archive/copy_op.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package archive
 
 import (
@@ -98,7 +97,7 @@ func (c *CopyOperation) Execute() error {
 			if err := copier.CopyDir(src, c.dst, c.uid, c.gid); err != nil {
 				return fmt.Errorf("copy dir %s to dir %s: %s", src, c.dst, err)
 			}
-		} else if strings.HasSuffix(c.dst, "/") || c.dst == "." || c.dst == ".." {
+		} else if isDirFormat(c.dst) {
 			// File to dir
 			targetFilePath := filepath.Join(c.dst, filepath.Base(src))
 			if err := copier.CopyFile(src, targetFilePath, c.uid, c.gid); err != nil {
@@ -164,7 +163,7 @@ func resolveDestination(workDir, dst string) string {
 	}
 	absDst := filepath.Join(workDir, dst)
 	// Preserve trailing "/".
-	if strings.HasSuffix(dst, "/") {
+	if isDirFormat(dst) {
 		absDst += "/"
 	}
 	return absDst
@@ -173,10 +172,14 @@ func resolveDestination(workDir, dst string) string {
 func checkCopyParams(srcs []string, workDir, dst string) error {
 	if len(srcs) == 0 {
 		return fmt.Errorf("srcs cannot be empty")
-	} else if len(srcs) > 1 && !strings.HasSuffix(dst, "/") {
+	} else if len(srcs) > 1 && !isDirFormat(dst) {
 		return fmt.Errorf("tarring multiple sources, destination must end with \"/\"")
 	} else if !filepath.IsAbs(dst) && !filepath.IsAbs(workDir) {
 		return fmt.Errorf("dst is not absolute path, must specify absolute working directory")
 	}
 	return nil
+}
+
+func isDirFormat(dst string) bool {
+	return strings.HasSuffix(dst, "/") || dst == "." || dst == ".."
 }

--- a/lib/archive/copy_op_test.go
+++ b/lib/archive/copy_op_test.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package archive
 
 import (
@@ -170,6 +169,31 @@ func TestExecuteCopyOperation(t *testing.T) {
 		require.NoError(err)
 		require.Equal(_hello, b)
 		b, err = ioutil.ReadFile(filepath.Join(tmpRoot2, dst, "test2.txt"))
+		require.NoError(err)
+		require.Equal(_hello2, b)
+	})
+	removeAllChildren(tmpRoot1, nil)
+	removeAllChildren(tmpRoot2, nil)
+
+	t.Run("absolute files to relative dir", func(t *testing.T) {
+		require := require.New(t)
+
+		srcs := []string{"/test.txt", "/test2.txt"}
+		require.NoError(ioutil.WriteFile(filepath.Join(tmpRoot1, "test.txt"), _hello, os.ModePerm))
+		require.NoError(os.Chown(filepath.Join(tmpRoot1, "test.txt"), testutil.CurrUID(), testutil.CurrGID()))
+		require.NoError(ioutil.WriteFile(filepath.Join(tmpRoot1, "test2.txt"), _hello2, os.ModePerm))
+		require.NoError(os.Chown(filepath.Join(tmpRoot1, "test2.txt"), testutil.CurrUID(), testutil.CurrGID()))
+		srcRoot := tmpRoot1
+		workDir := filepath.Join(tmpRoot2, "test2")
+		dst := "."
+		c, err := NewCopyOperation(
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false)
+		require.NoError(err)
+		require.NoError(c.Execute())
+		b, err := ioutil.ReadFile(filepath.Join(tmpRoot2, "test2", "test.txt"))
+		require.NoError(err)
+		require.Equal(_hello, b)
+		b, err = ioutil.ReadFile(filepath.Join(tmpRoot2, "test2", "test2.txt"))
 		require.NoError(err)
 		require.Equal(_hello2, b)
 	})


### PR DESCRIPTION
Previously the following would fail:
ADD file .

Now we handle this correctly.