### PR TITLE
Disabled caller logging

### DIFF
--- a/cli/application.go
+++ b/cli/application.go
@@ -141,6 +141,7 @@ func (app *BuildApplication) getLogger() (*zap.Logger, error) {
 
 	config.Encoding = app.LogFormat
 	config.DisableStacktrace = true
+	config.DisableCaller = true
 	return config.Build()
 }
 


### PR DESCRIPTION
This removes the "caller" field in our logs which is _always_ "lib/log/logger.go".