### PR TITLE
Removed unnecessary mounting of binary in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ cunit-test: $(ALL_SRC) vendor
 		golang:$(GO_VERSION) \
 		-c "make ext-tools unit-test"
 
-integration: bins env image
+integration: env image
 	PACKAGE_VERSION=$(PACKAGE_VERSION) ./env/bin/py.test --maxfail=1 --durations=6 --timeout=300 -vv test/python
 
 

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -72,7 +72,6 @@ def makisu_run_cmd(volumes, args):
 
     # Add volumes to docker command.
     volumes['/var/run/docker.sock'] = '/docker.sock'  # Mount docker socket
-    volumes[os.path.join(os.getcwd(), 'bin', 'makisu', 'makisu')] = '/makisu-internal/makisu'  # Mount makisu binary
     for k, v in volumes.iteritems():
         cmd.extend(['-v', '{path_outside}:{path_inside}'.format(path_outside=k, path_inside=v)])
 


### PR DESCRIPTION
This means that you only need python and docker installed (and not go) to run `make integration`.