### PR TITLE
Fixed output of --help flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ created with an init container, which will fetch the build context through git o
 that context in a designated volume. Once it completes, the Makisu container will be created and executes
 the build, using that volume as its build context.
 
+For a full list of flags, run `makisu --help`, `makisu build --help` or refer to the README [here](cli/README.md).
+
 ### Creating registry configuration
 
 Makisu needs registry configuration mounted to push to a secure registry. The config format is described [here](#configuring-docker-registry). After creating configuration file on local filesystem, run the following 

--- a/bin/makisu/main.go
+++ b/bin/makisu/main.go
@@ -19,14 +19,11 @@ import (
 	"os"
 
 	"github.com/uber/makisu/cli"
-	"github.com/uber/makisu/lib/utils"
 
 	"github.com/apourchet/commander"
 )
 
 func main() {
-	log.Printf("Starting makisu (version=%s)", utils.BuildHash)
-
 	application := cli.NewBuildApplication()
 	cmd := commander.New()
 	if err := cmd.RunCLI(application, os.Args[1:]); err != nil {

--- a/cli/README.md
+++ b/cli/README.md
@@ -17,8 +17,6 @@ Usage of makisu:
 
 Sub-Commands:
   build  |  Builds a docker image from a build context and a dockerfile.
-2018/11/19 15:34:33 Command failure: Need to specify a command for makisu. One of 'build', 'help' or 'version'
-exit status 1
 
 $ makisu build --help
 Usage of makisu build:
@@ -56,8 +54,6 @@ Usage of makisu build:
   -storage
     	Directory that makisu uses for temp files and cached layers. Mount this path for better caching performance. If modifyfs is set, default to /makisu-storage; Otherwise default to /tmp/makisu-storage. (type: string, default: "")
   -t	image tag (required) (type: string, default: "")
-2018/11/19 15:35:13 Command failure: flag: help requested
-exit status 1
 
 $ makisu version
 v0.1.0

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,64 @@
+# Makisu Usage Information
+--------------------------
+
+```
+$ makisu --help
+Usage of makisu:
+  -cpu-profile
+    	Profile the application. (type: bool, default: false)
+  -help
+    	Display usage information for Makisu. (type: bool, default: false)
+  -log-fmt
+    	The format of the logs. (type: string, default: "json")
+  -log-level
+    	The level at which to log. (type: string, default: "info")
+  -log-output
+    	The output file path for the logs. (type: string, default: "stdout")
+
+Sub-Commands:
+  build  |  Builds a docker image from a build context and a dockerfile.
+2018/11/19 15:34:33 Command failure: Need to specify a command for makisu. One of 'build', 'help' or 'version'
+exit status 1
+
+$ makisu build --help
+Usage of makisu build:
+  -blacklist
+    	Comma separated list of files/directories. Makisu will omit all changes to these locations in the resulting docker images. (type: string, default: "")
+  -build-args
+    	Arguments to the dockerfile as per the spec of ARG. Format is a json object. (type: map, default: {})
+  -commit
+    	Set to explicit to only commit at steps with '#!COMMIT' annotations; Set to implicit to commit at every ADD/COPY/RUN step. (type: string, default: "implicit")
+  -compression
+    	Image compression level, could be 'no', 'speed', 'size', 'default'. (type: string, default: "default")
+  -dest
+    	Destination of the image tar. (type: string, default: "")
+  -docker-host
+    	Docker host to load images to. (type: string, default: "unix:///var/run/docker.sock")
+  -docker-scheme
+    	Scheme for api calls to docker daemon. (type: string, default: "http")
+  -docker-version
+    	Version string for loading images to docker. (type: string, default: "1.21")
+  -f	The absolute path to the dockerfile (type: string, default: "Dockerfile")
+  -file-cache-path
+    	The path of a local file for cacheID to layer sha mapping. Used for testing only. (type: string, default: "")
+  -load
+    	Load image after build. (type: bool, default: false)
+  -modifyfs
+    	Allow makisu to touch files outside of its own storage dir. (type: bool, default: false)
+  -push
+    	Push image after build to the comma-separated list of registries. (type: string, default: "")
+  -redis-cache-addr
+    	The address of a redis cache server for cacheID to layer sha mapping. (type: string, default: "")
+  -redis-cache-ttl
+    	The TTL of each cacheID-sha mapping entry in seconds. (type: int, default: 604800)
+  -registry-config
+    	Registry configuration file for pulling and pushing images. Default configuration for DockerHub is used if not specified. (type: string, default: "")
+  -storage
+    	Directory that makisu uses for temp files and cached layers. Mount this path for better caching performance. If modifyfs is set, default to /makisu-storage; Otherwise default to /tmp/makisu-storage. (type: string, default: "")
+  -t	image tag (required) (type: string, default: "")
+2018/11/19 15:35:13 Command failure: flag: help requested
+exit status 1
+
+$ makisu version
+v0.1.0
+```

--- a/cli/build.go
+++ b/cli/build.go
@@ -168,6 +168,7 @@ func (cmd BuildFlags) GetTargetRegistries() []string {
 // If -push is specified, will also push the image to those registries.
 // If -load is specified, will load the image into the local docker daemon.
 func (cmd BuildFlags) Build(contextDir string) error {
+	log.Infof("Starting Makisu build (version=%s)", utils.BuildHash)
 	if cmd.Tag == "" {
 		return fmt.Errorf("please specify a target image name: makisu build -t=(<registry:port>/)<repo>:<tag> ./")
 	}


### PR DESCRIPTION
It now correctly displays the subcommands. Also added a `makisu version`
subcommand to display the version of the binary we are using.
Examples:
```
$ makisu --help
Usage of makisu:
  -cpu-profile
    	Profile the application. (type: bool, default: false)
  -help
    	Display usage information for Makisu. (type: bool, default: false)
  -log-fmt
    	The format of the logs. (type: string, default: "json")
  -log-level
    	The level at which to log. (type: string, default: "info")
  -log-output
    	The output file path for the logs. (type: string, default: "stdout")

Sub-Commands:
  build  |  Builds a docker image from a build context and a dockerfile.
2018/11/19 15:34:33 Command failure: Need to specify a command for makisu. One of 'build', 'help' or 'version'
exit status 1

$ makisu build --help
Usage of makisu build:
  -blacklist
    	Comma separated list of files/directories. Makisu will omit all changes to these locations in the resulting docker images. (type: string, default: "")
  -build-args
    	Arguments to the dockerfile as per the spec of ARG. Format is a json object. (type: map, default: {})
  -commit
    	Set to explicit to only commit at steps with '#!COMMIT' annotations; Set to implicit to commit at every ADD/COPY/RUN step. (type: string, default: "implicit")
  -compression
    	Image compression level, could be 'no', 'speed', 'size', 'default'. (type: string, default: "default")
  -dest
    	Destination of the image tar. (type: string, default: "")
  -docker-host
    	Docker host to load images to. (type: string, default: "unix:///var/run/docker.sock")
  -docker-scheme
    	Scheme for api calls to docker daemon. (type: string, default: "http")
  -docker-version
    	Version string for loading images to docker. (type: string, default: "1.21")
  -f	The absolute path to the dockerfile (type: string, default: "Dockerfile")
  -file-cache-path
    	The path of a local file for cacheID to layer sha mapping. Used for testing only. (type: string, default: "")
  -load
    	Load image after build. (type: bool, default: false)
  -modifyfs
    	Allow makisu to touch files outside of its own storage dir. (type: bool, default: false)
  -push
    	Push image after build to the comma-separated list of registries. (type: string, default: "")
  -redis-cache-addr
    	The address of a redis cache server for cacheID to layer sha mapping. (type: string, default: "")
  -redis-cache-ttl
    	The TTL of each cacheID-sha mapping entry in seconds. (type: int, default: 604800)
  -registry-config
    	Registry configuration file for pulling and pushing images. Default configuration for DockerHub is used if not specified. (type: string, default: "")
  -storage
    	Directory that makisu uses for temp files and cached layers. Mount this path for better caching performance. If modifyfs is set, default to /makisu-storage; Otherwise default to /tmp/makisu-storage. (type: string, default: "")
  -t	image tag (required) (type: string, default: "")
2018/11/19 15:35:13 Command failure: flag: help requested
exit status 1

$ makisu version
v0.1.0
```