### PR TITLE
Added support for `COPY --from=<image name>`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,10 @@ integration: env image
 
 
 ### Misc targets
-.PHONY: clean
+.PHONY: clean integration-single
+integration-single: env image
+	PACKAGE_VERSION=$(PACKAGE_VERSION) ./env/bin/py.test test/python/test_build.py::$(TEST_NAME)
+
 clean:
 	git clean -fd
 	-rm -rf vendor ext-tools mocks env

--- a/lib/builder/build_plan_test.go
+++ b/lib/builder/build_plan_test.go
@@ -92,11 +92,11 @@ func TestBuildPlanContextDirs(t *testing.T) {
 
 	plan, err := NewBuildPlan(ctx, target, cacheMgr, stages, false, false)
 	require.NoError(err)
-	require.Contains(plan.contextDirs, "stage1")
-	require.Len(plan.contextDirs, 1)
-	require.Contains(plan.contextDirs["stage1"], "/hello")
-	require.Contains(plan.contextDirs["stage1"], "/hello2")
-	require.Len(plan.contextDirs["stage1"], 2)
+	require.Contains(plan.crossRefDirs, "stage1")
+	require.Len(plan.crossRefDirs, 1)
+	require.Contains(plan.crossRefDirs["stage1"], "/hello")
+	require.Contains(plan.crossRefDirs["stage1"], "/hello2")
+	require.Len(plan.crossRefDirs["stage1"], 2)
 
 	// Copy from nonexistent stage.
 	from := dockerfile.FromDirectiveFixture("", envImage.String(), "")

--- a/lib/builder/build_plan_test.go
+++ b/lib/builder/build_plan_test.go
@@ -90,7 +90,10 @@ func TestBuildPlanContextDirs(t *testing.T) {
 	}
 	stages := []*dockerfile.Stage{{from1, nil}, {from2, directives2}, {from3, directives3}}
 
-	plan, err := NewBuildPlan(ctx, target, cacheMgr, stages, false, false)
+	// Here we need to set the allowModifyFS to true because we copy
+	// files accross stages.
+	// TODO(pourchet): support copy --from without relying on FS.
+	plan, err := NewBuildPlan(ctx, target, cacheMgr, stages, true, false)
 	require.NoError(err)
 	require.Contains(plan.crossRefDirs, "stage1")
 	require.Len(plan.crossRefDirs, 1)

--- a/lib/builder/build_plan_test.go
+++ b/lib/builder/build_plan_test.go
@@ -95,11 +95,11 @@ func TestBuildPlanContextDirs(t *testing.T) {
 	// TODO(pourchet): support copy --from without relying on FS.
 	plan, err := NewBuildPlan(ctx, target, cacheMgr, stages, true, false)
 	require.NoError(err)
-	require.Contains(plan.crossRefDirs, "stage1")
-	require.Len(plan.crossRefDirs, 1)
-	require.Contains(plan.crossRefDirs["stage1"], "/hello")
-	require.Contains(plan.crossRefDirs["stage1"], "/hello2")
-	require.Len(plan.crossRefDirs["stage1"], 2)
+	require.Contains(plan.copyFromDirs, "stage1")
+	require.Len(plan.copyFromDirs, 1)
+	require.Contains(plan.copyFromDirs["stage1"], "/hello")
+	require.Contains(plan.copyFromDirs["stage1"], "/hello2")
+	require.Len(plan.copyFromDirs["stage1"], 2)
 
 	// Copy from nonexistent stage.
 	from := dockerfile.FromDirectiveFixture("", envImage.String(), "")

--- a/lib/builder/build_stage.go
+++ b/lib/builder/build_stage.go
@@ -37,7 +37,7 @@ import (
 // buildStage represents a sequence of steps to build intermediate layers or a final image.
 type buildStage struct {
 	ctx               *context.BuildContext
-	contextDirs       map[string][]string
+	crossRefDirs      map[string][]string
 	alias             string
 	nodes             []*buildNode
 	lastImageConfig   *image.Config
@@ -68,7 +68,7 @@ func newBuildStage(
 
 	stage := &buildStage{
 		ctx:               ctx,
-		contextDirs:       make(map[string][]string),
+		crossRefDirs:      make(map[string][]string),
 		alias:             parsedStage.From.Alias,
 		nodes:             make([]*buildNode, 0),
 		sharedDigestPairs: digestPairs,
@@ -104,10 +104,10 @@ func (stage *buildStage) convertParsedStage(
 		// Add context dirs for cross-stage copy, if any.
 		alias, dirs := s.ContextDirs()
 		if len(dirs) > 0 {
-			if _, ok := stage.contextDirs[alias]; !ok {
-				stage.contextDirs[alias] = make([]string, 0)
+			if _, ok := stage.crossRefDirs[alias]; !ok {
+				stage.crossRefDirs[alias] = make([]string, 0)
 			}
-			stage.contextDirs[alias] = append(stage.contextDirs[alias], dirs...)
+			stage.crossRefDirs[alias] = append(stage.crossRefDirs[alias], dirs...)
 		}
 		if s.RequireOnDisk() {
 			stage.requireOnDisk = true

--- a/lib/builder/build_stage.go
+++ b/lib/builder/build_stage.go
@@ -29,9 +29,7 @@ import (
 	"github.com/uber/makisu/lib/context"
 	"github.com/uber/makisu/lib/docker/image"
 	"github.com/uber/makisu/lib/log"
-	"github.com/uber/makisu/lib/parser/dockerfile"
 	"github.com/uber/makisu/lib/storage"
-	"github.com/uber/makisu/lib/utils"
 )
 
 // buildStage represents a sequence of steps to build intermediate layers or a final image.
@@ -41,7 +39,7 @@ type buildStage struct {
 	alias             string
 	nodes             []*buildNode
 	lastImageConfig   *image.Config
-	sharedDigestPairs map[string][]*image.DigestPair
+	sharedDigestPairs image.DigestPairMap
 
 	requireOnDisk bool
 
@@ -55,8 +53,8 @@ type buildStage struct {
 
 // newBuildStage initializes a buildStage.
 func newBuildStage(
-	baseCtx *context.BuildContext, parsedStage *dockerfile.Stage,
-	digestPairs map[string][]*image.DigestPair,
+	baseCtx *context.BuildContext, alias string,
+	steps []step.BuildStep, digestPairs image.DigestPairMap,
 	allowModifyFS, forceCommit bool) (*buildStage, error) {
 
 	// Create a new build context for the stage.
@@ -69,7 +67,7 @@ func newBuildStage(
 	stage := &buildStage{
 		ctx:               ctx,
 		crossRefDirs:      make(map[string][]string),
-		alias:             parsedStage.From.Alias,
+		alias:             alias,
 		nodes:             make([]*buildNode, 0),
 		sharedDigestPairs: digestPairs,
 		allowModifyFS:     allowModifyFS,
@@ -77,7 +75,7 @@ func newBuildStage(
 	}
 
 	// Convert each directive in the parsed stage to a build node.
-	if err := stage.convertParsedStage(ctx, parsedStage); err != nil {
+	if err := stage.createNodes(ctx, steps); err != nil {
 		return nil, fmt.Errorf("convert parsed stage to build stage: %s", err)
 	}
 	return stage, nil
@@ -85,31 +83,20 @@ func newBuildStage(
 
 // convertParsedStage converts the directives in a parsed stage to build steps and keeps
 // track of directories needed for cross-stage copy operations.
-func (stage *buildStage) convertParsedStage(
-	ctx *context.BuildContext, parsedStage *dockerfile.Stage) error {
-
-	seed := utils.BuildHash
-	parsedStage.Directives = append([]dockerfile.Directive{parsedStage.From},
-		parsedStage.Directives...)
-	for _, directive := range parsedStage.Directives {
-		s, err := step.NewDockerfileStep(ctx, directive, seed)
-		if err != nil {
-			return fmt.Errorf("convert directive to build step: %s", err)
-		}
-
-		newNode := newBuildNode(ctx, s)
+func (stage *buildStage) createNodes(ctx *context.BuildContext, steps []step.BuildStep) error {
+	for _, step := range steps {
+		newNode := newBuildNode(ctx, step)
 		stage.nodes = append(stage.nodes, newNode)
-		seed = s.CacheID()
 
 		// Add context dirs for cross-stage copy, if any.
-		alias, dirs := s.ContextDirs()
+		alias, dirs := step.ContextDirs()
 		if len(dirs) > 0 {
 			if _, ok := stage.crossRefDirs[alias]; !ok {
 				stage.crossRefDirs[alias] = make([]string, 0)
 			}
 			stage.crossRefDirs[alias] = append(stage.crossRefDirs[alias], dirs...)
 		}
-		if s.RequireOnDisk() {
+		if step.RequireOnDisk() {
 			stage.requireOnDisk = true
 		}
 	}
@@ -285,3 +272,13 @@ func (stage *buildStage) latestFetched() int {
 func (stage *buildStage) String() string {
 	return fmt.Sprintf("(alias=%v,latestfetched=%v)", stage.alias, stage.latestFetched())
 }
+
+// checkpoint copies over the cross stage referenced files and directories to the cross ref root
+// location inside a blacklisted directory. Those files will be copied back onto the real root
+// of the fs once the step that references them gets executed.
+func (stage *buildStage) checkpoint(crossRefDirs []string) error {
+	newRoot := stage.ctx.CrossRefRoot(stage.alias)
+	return stage.ctx.MemFS.Checkpoint(newRoot, crossRefDirs)
+}
+
+func (stage *buildStage) cleanup() error { return stage.ctx.MemFS.Remove() }

--- a/lib/builder/build_stage_test.go
+++ b/lib/builder/build_stage_test.go
@@ -17,6 +17,7 @@ package builder
 import (
 	"testing"
 
+	"github.com/uber/makisu/lib/builder/step"
 	"github.com/uber/makisu/lib/cache"
 	"github.com/uber/makisu/lib/context"
 	"github.com/uber/makisu/lib/docker/image"
@@ -116,8 +117,11 @@ func TestPullCacheLayers(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 
-			stage, err := newBuildStage(
-				ctx, tc.stage, map[string][]*image.DigestPair{}, false, false)
+			alias := tc.stage.From.Alias
+			steps, err := step.NewDockerfileSteps(ctx, tc.stage)
+			require.NoError(err)
+
+			stage, err := newBuildStage(ctx, alias, steps, image.DigestPairMap{}, false, false)
 			require.NoError(err)
 
 			imageName, err := image.ParseName("registry.net/repo:tag")

--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -178,7 +178,7 @@ func (s *addCopyStep) resolveFromPaths(ctx *context.BuildContext) []string {
 
 func (s *addCopyStep) contextRootDir(ctx *context.BuildContext) string {
 	if s.fromStage != "" {
-		return ctx.StageDir(s.fromStage)
+		return ctx.CrossRefRoot(s.fromStage)
 	}
 	return ctx.ContextDir
 }

--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -178,7 +178,7 @@ func (s *addCopyStep) resolveFromPaths(ctx *context.BuildContext) []string {
 
 func (s *addCopyStep) contextRootDir(ctx *context.BuildContext) string {
 	if s.fromStage != "" {
-		return ctx.CrossRefRoot(s.fromStage)
+		return ctx.CopyFromRoot(s.fromStage)
 	}
 	return ctx.ContextDir
 }

--- a/lib/context/build_context.go
+++ b/lib/context/build_context.go
@@ -15,6 +15,7 @@
 package context
 
 import (
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -71,9 +72,12 @@ func NewBuildContext(
 	}, nil
 }
 
-// StageDir returns the directory that context from a stage should be written to and read from.
-func (ctx *BuildContext) StageDir(alias string) string {
-	return filepath.Join(ctx.stagesDir, alias)
+// CrossRefRoot returns the directory that context from a stage should be written to and read from.
+func (ctx *BuildContext) CrossRefRoot(alias string) string {
+	// Here we sha the alias to get a string that can be directly appended to the context's
+	// root crossRefDir.
+	dirname := base64.URLEncoding.EncodeToString([]byte(alias))
+	return filepath.Join(ctx.stagesDir, string(dirname))
 }
 
 // Cleanup cleans up files kept across stages after the build is completed.

--- a/lib/context/build_context.go
+++ b/lib/context/build_context.go
@@ -72,10 +72,10 @@ func NewBuildContext(
 	}, nil
 }
 
-// CrossRefRoot returns the directory that context from a stage should be written to and read from.
-func (ctx *BuildContext) CrossRefRoot(alias string) string {
+// CopyFromRoot returns the directory that context from a stage should be written to and read from.
+func (ctx *BuildContext) CopyFromRoot(alias string) string {
 	// Here we sha the alias to get a string that can be directly appended to the context's
-	// root crossRefDir.
+	// root sandbox stage directory.
 	dirname := base64.URLEncoding.EncodeToString([]byte(alias))
 	return filepath.Join(ctx.stagesDir, string(dirname))
 }

--- a/lib/docker/image/digest.go
+++ b/lib/docker/image/digest.go
@@ -25,6 +25,12 @@ import (
 // 	 sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
 type Digest string
 
+// DigestPairs is a list of DigestPair
+type DigestPairs []*DigestPair
+
+// DigestPairMap is a map from string to DigestPairs
+type DigestPairMap map[string]DigestPairs
+
 // Hex returns the hex part of the digest.
 // Example:
 //   e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/lib/parser/dockerfile/state.go
+++ b/lib/parser/dockerfile/state.go
@@ -20,6 +20,9 @@ type Stage struct {
 	Directives []Directive
 }
 
+// Stages is an alias for []*Stage.
+type Stages []*Stage
+
 func newStage(from *FromDirective) *Stage {
 	return &Stage{from, make([]Directive, 0)}
 }

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -29,6 +29,15 @@ def test_build_numbered_alias(registry1, storage_dir):
     assert code == 0, err
 
 
+def test_build_copy_from_image(registry1, storage_dir):
+    new_image = new_image_name()
+    # context_dir = os.path.join(os.getcwd(), 'testdata/build-context/copy-from-image')
+
+    # utils.makisu_build_image(new_image, registry1.addr, context_dir, storage_dir, load=True)
+    # code, err = utils.docker_run_image(registry1.addr, new_image)
+    # assert code == 0, err
+
+
 def test_build_delete_intermediate(registry1, storage_dir):
     new_image = new_image_name()
     context_dir = os.path.join(os.getcwd(), 'testdata/build-context/delete-intermediate')

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -31,11 +31,11 @@ def test_build_numbered_alias(registry1, storage_dir):
 
 def test_build_copy_from_image(registry1, storage_dir):
     new_image = new_image_name()
-    # context_dir = os.path.join(os.getcwd(), 'testdata/build-context/copy-from-image')
+    context_dir = os.path.join(os.getcwd(), 'testdata/build-context/copy-from-image')
 
-    # utils.makisu_build_image(new_image, registry1.addr, context_dir, storage_dir, load=True)
-    # code, err = utils.docker_run_image(registry1.addr, new_image)
-    # assert code == 0, err
+    utils.makisu_build_image(new_image, registry1.addr, context_dir, storage_dir, load=True)
+    code, err = utils.docker_run_image(registry1.addr, new_image)
+    assert code == 0, err
 
 
 def test_build_delete_intermediate(registry1, storage_dir):

--- a/testdata/build-context/copy-from-image/Dockerfile
+++ b/testdata/build-context/copy-from-image/Dockerfile
@@ -1,4 +1,4 @@
 FROM busybox
 COPY --from=debian:8 /bin/bash /bash
-RUN /bash -c "echo OK"
-ENTRYPOINT ["/bin/sh", "-c", "ls /bin/bash"]
+RUN ls / && ls -la /bash
+ENTRYPOINT ["/bin/sh", "-c", "ls /bash"]

--- a/testdata/build-context/copy-from-image/Dockerfile
+++ b/testdata/build-context/copy-from-image/Dockerfile
@@ -1,0 +1,4 @@
+FROM busybox
+COPY --from=debian:8 /bin/bash /bash
+RUN /bash -c "echo OK"
+ENTRYPOINT ["/bin/sh", "-c", "ls /bin/bash"]


### PR DESCRIPTION
- Renamed `ContextDirs` to `CopyFromDirs` and `CopyFromRoot`
- Added helper methods on `*buildStage` so as to not directly access `stage.ctx.MemFS`
- Split up the build plan initialization into multiple passes to handle aliases and cross stage refs separately
- Added integration test for the `COPY --from=<image name>` use case

Fixes #55