### PR TITLE
Sped up integration tests

### DIFF
--- a/testdata/build-context/arg-and-env/Dockerfile
+++ b/testdata/build-context/arg-and-env/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE="golang:1.10"
+ARG BASE_IMAGE="busybox:latest"
 ARG RUNTIME_BASE_IMAGE="alpine"
 
 # construct build image

--- a/testdata/build-context/go-from-scratch/Dockerfile
+++ b/testdata/build-context/go-from-scratch/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest AS phase1
+FROM golang:1.11.1 AS phase1
 
 # Perform build
 COPY . /home/udocker/test-scratch

--- a/testdata/build-context/numbered-alias/Dockerfile
+++ b/testdata/build-context/numbered-alias/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM busybox:latest
 RUN echo "OK" > /test1
 
 FROM debian:8

--- a/testdata/build-context/simple/Dockerfile
+++ b/testdata/build-context/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM debian:8
 
 MAINTAINER foo@bar
 ENV TEST=testenv


### PR DESCRIPTION
The golang image we were using in integration tests is really heavy,
which makes the tests really slow. By using debian or busybox we can
speed those up.
Before vs after on Macbook Pro:
```
12 passed in 463.51 seconds
12 passed in 399.83 seconds
```