### PR TITLE
Make TLS enabled by default and add default config for Docker Hub

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -124,6 +124,9 @@ func (cmd *BuildFlags) postInit() error {
 				registry.ConfigurationMap[reg][repo] = config
 			}
 		}
+	} else {
+		registry.ConfigurationMap[image.DockerHubRegistry] = make(registry.RepositoryMap)
+		registry.ConfigurationMap[image.DockerHubRegistry][".*"] = registry.DefaultDockerHubConfiguration
 	}
 
 	// Verify storage dir is not child of internal dir.

--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -32,9 +32,8 @@ var ConfigurationMap = Map{
 // DefaultDockerHubConfiguration contains docker hub registry configuration.
 var DefaultDockerHubConfiguration = Config{
 	Security: security.Config{
-		TLS: &httputil.TLSConfig{
-			Client: httputil.X509Pair{Enabled: true}},
-		BasicAuth: &types.AuthConfig{},
+		TLS:       &httputil.TLSConfig{},
+		BasicAuth: &types.AuthConfig{}, // DockerHub requires empty username and password for public repositories.
 	}}
 
 // Map contains a map of registry config.

--- a/lib/registry/fixtures.go
+++ b/lib/registry/fixtures.go
@@ -76,7 +76,9 @@ func PullClientFixture(ctx *context.BuildContext, testdataDir string) (*DockerRe
 			testdataDir: testdataDir,
 		},
 	}
-	return NewWithClient(ctx.ImageStore, image.GetRegistry(), image.GetRepository(), cli), nil
+	c := NewWithClient(ctx.ImageStore, image.GetRegistry(), image.GetRepository(), cli)
+	c.config.Security.TLS.Client.Disabled = true
+	return c, nil
 }
 
 type pullTransportFixture struct {
@@ -156,7 +158,9 @@ func PushClientFixture(ctx *context.BuildContext) (*DockerRegistryClient, error)
 	cli := &http.Client{
 		Transport: pushTransportFixture{image},
 	}
-	return NewWithClient(ctx.ImageStore, image.GetRegistry(), image.GetRepository(), cli), nil
+	c := NewWithClient(ctx.ImageStore, image.GetRegistry(), image.GetRepository(), cli)
+	c.config.Security.TLS.Client.Disabled = true
+	return c, nil
 }
 
 type pushTransportFixture struct {

--- a/lib/utils/httputil/tls.go
+++ b/lib/utils/httputil/tls.go
@@ -42,7 +42,7 @@ type TLSConfig struct {
 // X509Pair contains x509 cert configuration.
 // Both Cert and Key should be already in pem format.
 type X509Pair struct {
-	Enabled    bool   `yaml:"enabled"`
+	Disabled   bool   `yaml:"disabled"`
 	Cert       Secret `yaml:"cert"`
 	Key        Secret `yaml:"key"`
 	Passphrase Secret `yaml:"passphrase"`
@@ -55,8 +55,8 @@ type Secret struct {
 
 // BuildClient builts tls.Config for http client.
 func (c *TLSConfig) BuildClient() (*tls.Config, error) {
-	if !c.Client.Enabled {
-		log.Debugf("Client TLS is disabled")
+	if c.Client.Disabled {
+		log.Infof("Client TLS is disabled")
 		return nil, nil
 	}
 	if c.tls != nil {

--- a/lib/utils/httputil/tls_test.go
+++ b/lib/utils/httputil/tls_test.go
@@ -129,11 +129,9 @@ func genCerts(t *testing.T) (config *TLSConfig, cleanupfunc func()) {
 
 	config = &TLSConfig{}
 	config.Name = "kraken"
-	config.CA.Enabled = true
 	config.CA.Cert.Path = sCert
 	config.CA.Key.Path = sKey
 	config.CA.Passphrase.Path = sSecret
-	config.Client.Enabled = true
 	config.Client.Cert.Path = cCert
 	config.Client.Key.Path = cKey
 	config.Client.Passphrase.Path = cSecret


### PR DESCRIPTION
For the ease of pulling images from public Docker Hub repos, a default config is added so makisu would use https + basic auth with empty username and password as required by Docker.

TLS is enabled by default as a common practice. 