### PR TITLE
Consider some commandline options in cache ID calculaton

### DIFF
--- a/lib/builder/build_node.go
+++ b/lib/builder/build_node.go
@@ -28,11 +28,11 @@ import (
 	"github.com/uber/makisu/lib/tario"
 )
 
-// buildOptions wraps options that are specified when a node is built.
-type buildOptions struct {
-	modifyFS    bool // If true, the node will modify the file system.
+// buildNodeOptions wraps options that are specified when a node is built.
+type buildNodeOptions struct {
 	skipBuild   bool // If true, the node will not call build on its build step.
 	forceCommit bool // If true, the node will always commit a layer if it can.
+	modifyFS    bool // If true, the node will modify the file system.
 }
 
 // buildNode corresponds to a single BuildStep and its metadata.
@@ -60,7 +60,8 @@ func newBuildNode(ctx *context.BuildContext, step step.BuildStep) *buildNode {
 // a layer.
 // TODO: Build and push intermediate cache layers concurrently.
 func (n *buildNode) Build(
-	cacheMgr cache.Manager, prevConfig *image.Config, opts *buildOptions) (*image.Config, error) {
+	cacheMgr cache.Manager, prevConfig *image.Config,
+	opts *buildNodeOptions) (*image.Config, error) {
 
 	// Always apply config.
 	if err := n.ApplyCtxAndConfig(n.ctx, prevConfig); err != nil {
@@ -98,7 +99,7 @@ func (n *buildNode) Build(
 	return config, nil
 }
 
-func (n *buildNode) doCommit(cacheMgr cache.Manager, opts *buildOptions) error {
+func (n *buildNode) doCommit(cacheMgr cache.Manager, opts *buildNodeOptions) error {
 	var err error
 	n.digestPairs, err = n.Commit(n.ctx)
 	if err != nil {
@@ -117,7 +118,7 @@ func (n *buildNode) doCommit(cacheMgr cache.Manager, opts *buildOptions) error {
 	return nil
 }
 
-func (n *buildNode) doExecute(cacheMgr cache.Manager, opts *buildOptions) error {
+func (n *buildNode) doExecute(cacheMgr cache.Manager, opts *buildNodeOptions) error {
 	start := time.Now()
 	err := n.Execute(n.ctx, opts.modifyFS)
 	if err != nil {
@@ -174,7 +175,7 @@ func (n *buildNode) pullCacheLayer(cacheMgr cache.Manager) bool {
 	return true
 }
 
-func (opts *buildOptions) String() string {
+func (opts *buildNodeOptions) String() string {
 	s := []string{}
 	if opts.skipBuild {
 		s = append(s, "skip")

--- a/lib/builder/build_stage.go
+++ b/lib/builder/build_stage.go
@@ -149,8 +149,7 @@ func newBuildStageHelper(
 	return stage, nil
 }
 
-// createDockerfileSteps returns a list of steps that correspond to the steps of
-// the stage passed in as input.
+// createDockerfileSteps returns a list of build steps given a parsed stage.
 func createDockerfileSteps(
 	ctx *context.BuildContext, stage *dockerfile.Stage,
 	planOpts *buildPlanOptions) ([]step.BuildStep, error) {

--- a/lib/builder/build_stage_test.go
+++ b/lib/builder/build_stage_test.go
@@ -17,7 +17,6 @@ package builder
 import (
 	"testing"
 
-	"github.com/uber/makisu/lib/builder/step"
 	"github.com/uber/makisu/lib/cache"
 	"github.com/uber/makisu/lib/context"
 	"github.com/uber/makisu/lib/docker/image"
@@ -118,10 +117,12 @@ func TestPullCacheLayers(t *testing.T) {
 			require := require.New(t)
 
 			alias := tc.stage.From.Alias
-			steps, err := step.NewDockerfileSteps(ctx, tc.stage)
-			require.NoError(err)
+			opts := &buildPlanOptions{
+				forceCommit:   false,
+				allowModifyFS: false,
+			}
 
-			stage, err := newBuildStage(ctx, alias, steps, image.DigestPairMap{}, false, false)
+			stage, err := newBuildStage(ctx, alias, tc.stage, image.DigestPairMap{}, opts)
 			require.NoError(err)
 
 			kvstore := cache.MemKVStore{}

--- a/lib/builder/step/step.go
+++ b/lib/builder/step/step.go
@@ -20,7 +20,6 @@ import (
 	"github.com/uber/makisu/lib/context"
 	"github.com/uber/makisu/lib/docker/image"
 	"github.com/uber/makisu/lib/parser/dockerfile"
-	"github.com/uber/makisu/lib/utils"
 )
 
 // Directive represents a valid directive type.
@@ -61,40 +60,26 @@ type BuildStep interface {
 	// SetCacheID sets the cache ID of the step given a seed value.
 	SetCacheID(ctx *context.BuildContext, seed string) error
 
-	// ApplyCtxAndConfig sets up the execution environment using image config from previous step.
+	// ApplyCtxAndConfig sets up the execution environment using image config
+	// from previous step.
 	// This function will not be skipped.
 	ApplyCtxAndConfig(ctx *context.BuildContext, imageConfig *image.Config) error
 
-	// Execute executes the step. If modifyFS is true, the command might change the local
-	// file system.
+	// Execute executes the step. If modifyFS is true, the command might change
+	// the local file system.
 	Execute(ctx *context.BuildContext, modifyFS bool) error
 
 	// Commit generates an image layer.
 	Commit(ctx *context.BuildContext) ([]*image.DigestPair, error)
 
-	// UpdateCtxAndConfig generates a new image config base on config from previous step.
+	// UpdateCtxAndConfig generates a new image config base on config from
+	// previous step.
 	// This function will not be skipped.
 	UpdateCtxAndConfig(ctx *context.BuildContext, imageConfig *image.Config) (*image.Config, error)
 
-	// HasCommit returns whether or not a particular commit step has a commit annotation.
+	// HasCommit returns whether or not a particular commit step has a commit
+	// annotation.
 	HasCommit() bool
-}
-
-// NewDockerfileSteps returns a list of steps that correspond to the steps of the stage
-// passed in as input.
-func NewDockerfileSteps(ctx *context.BuildContext, stage *dockerfile.Stage) ([]BuildStep, error) {
-	seed := utils.BuildHash
-	directives := append([]dockerfile.Directive{stage.From}, stage.Directives...)
-	var steps []BuildStep
-	for _, directive := range directives {
-		step, err := NewDockerfileStep(ctx, directive, seed)
-		if err != nil {
-			return nil, fmt.Errorf("directive to build step: %v", err)
-		}
-		steps = append(steps, step)
-		seed = step.CacheID()
-	}
-	return steps, nil
 }
 
 // NewDockerfileStep initializes a build step from a dockerfile directive.


### PR DESCRIPTION
ref #99

So builds with -commit=explicit and those with -commit=implicit build processes wouldn't share cache.