### PR TITLE
Fixed log message for ARG step

### DIFF
--- a/lib/builder/step/arg_step.go
+++ b/lib/builder/step/arg_step.go
@@ -30,7 +30,7 @@ type ArgStep struct {
 // NewArgStep returns a BuildStep from given arguments.
 func NewArgStep(args string, name string, resolvedVal *string, commit bool) BuildStep {
 	return &ArgStep{
-		baseStep:    newBaseStep(Env, args, commit),
+		baseStep:    newBaseStep(Arg, args, commit),
 		name:        name,
 		resolvedVal: resolvedVal,
 	}

--- a/lib/builder/step/step.go
+++ b/lib/builder/step/step.go
@@ -28,6 +28,7 @@ type Directive string
 // Set of all valid directives.
 const (
 	Add         = Directive("ADD")
+	Arg         = Directive("ARG")
 	Cmd         = Directive("CMD")
 	Copy        = Directive("COPY")
 	Entrypoint  = Directive("ENTRYPOINT")


### PR DESCRIPTION
It was previously printing "ENV" instead of "ARG".