### PR TITLE
Cleanup error handling logic

### DIFF
--- a/cli/build.go
+++ b/cli/build.go
@@ -89,7 +89,7 @@ func newBuildFlags() BuildFlags {
 
 func (cmd *BuildFlags) postInit() error {
 	if err := cmd.maybeBlacklistVarRun(); err != nil {
-		return fmt.Errorf("failed to extend blacklist: %v", err)
+		return fmt.Errorf("failed to extend blacklist: %s", err)
 	}
 
 	if cmd.Blacklist != "" {
@@ -108,7 +108,7 @@ func (cmd *BuildFlags) postInit() error {
 	}
 
 	if err := cmd.initRegistryConfig(); err != nil {
-		return fmt.Errorf("failed to initialize registry configuration: %v", err)
+		return fmt.Errorf("failed to initialize registry configuration: %s", err)
 	}
 
 	// If modifyfs is true, verify it's not runninng on Mac.
@@ -219,12 +219,12 @@ func (cmd BuildFlags) createBuildPlan(
 	// Read in and parse dockerfile.
 	dockerfile, err := cmd.getDockerfile(buildContext.ContextDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get dockerfile: %v", err)
+		return nil, fmt.Errorf("failed to get dockerfile: %s", err)
 	}
 
 	// Remove image manifest if an image with the same name already exists.
 	if err := cmd.cleanManifest(imageName); err != nil {
-		return nil, fmt.Errorf("failed to clean manifest: %v", err)
+		return nil, fmt.Errorf("failed to clean manifest: %s", err)
 	}
 
 	// Init cache manager.
@@ -243,7 +243,7 @@ func (cmd BuildFlags) Build(contextDir string) error {
 
 	imageName, err := cmd.getTargetImageName()
 	if err != nil {
-		return fmt.Errorf("failed to get target image name: %v", err)
+		return fmt.Errorf("failed to get target image name: %s", err)
 	}
 
 	// Convert context dir to absolute path.
@@ -279,21 +279,21 @@ func (cmd BuildFlags) Build(contextDir string) error {
 	for _, registry := range cmd.GetTargetRegistries() {
 		target := imageName.WithRegistry(registry)
 		if err := cmd.pushImage(target); err != nil {
-			return fmt.Errorf("failed to push image: %v", err)
+			return fmt.Errorf("failed to push image: %s", err)
 		}
 	}
 
 	// Optionally save image as a tar file.
 	if cmd.Destination != "" {
 		if err := cmd.saveImage(imageName); err != nil {
-			return fmt.Errorf("failed to save image: %v", err)
+			return fmt.Errorf("failed to save image: %s", err)
 		}
 	}
 
 	// Optionally load image to local docker daemon.
 	if cmd.DoLoad {
 		if err := cmd.loadImage(imageName); err != nil {
-			return fmt.Errorf("failed to load image: %v", err)
+			return fmt.Errorf("failed to load image: %s", err)
 		}
 	}
 

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -59,7 +59,7 @@ func (cmd BuildFlags) getDockerfile(contextDir string) ([]*dockerfile.Stage, err
 
 	dockerfile, err := dockerfile.ParseFile(string(contents), cmd.Arguments)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse dockerfile: %v", err)
+		return nil, fmt.Errorf("failed to parse dockerfile: %s", err)
 	}
 	return dockerfile, nil
 }

--- a/lib/builder/build_stage.go
+++ b/lib/builder/build_stage.go
@@ -161,7 +161,7 @@ func createDockerfileSteps(
 	for _, directive := range directives {
 		step, err := step.NewDockerfileStep(ctx, directive, seed)
 		if err != nil {
-			return nil, fmt.Errorf("directive to build step: %v", err)
+			return nil, fmt.Errorf("directive to build step: %s", err)
 		}
 		steps = append(steps, step)
 		seed = step.CacheID()

--- a/lib/builder/step/from_step.go
+++ b/lib/builder/step/from_step.go
@@ -101,12 +101,12 @@ func (s *FromStep) Execute(ctx *context.BuildContext, modifyFS bool) error {
 	// Otherwise, pull image.
 	manifest, err := s.getManifest(ctx.ImageStore)
 	if err != nil {
-		return fmt.Errorf("get manifest: %v", err)
+		return fmt.Errorf("get manifest: %s", err)
 	}
 
 	config, err := s.getConfig(manifest.Config, ctx.ImageStore)
 	if err != nil {
-		return fmt.Errorf("get config: %v", err)
+		return fmt.Errorf("get config: %s", err)
 	}
 
 	if config.RootFS.DiffIDs == nil || manifest.Layers == nil {
@@ -144,12 +144,12 @@ func (s *FromStep) Commit(ctx *context.BuildContext) ([]*image.DigestPair, error
 
 	manifest, err := s.getManifest(ctx.ImageStore)
 	if err != nil {
-		return nil, fmt.Errorf("get manifest: %v", err)
+		return nil, fmt.Errorf("get manifest: %s", err)
 	}
 
 	config, err := s.getConfig(manifest.Config, ctx.ImageStore)
 	if err != nil {
-		return nil, fmt.Errorf("get config: %v", err)
+		return nil, fmt.Errorf("get config: %s", err)
 	}
 
 	if config.RootFS.DiffIDs == nil || manifest.Layers == nil {
@@ -181,12 +181,12 @@ func (s *FromStep) UpdateCtxAndConfig(
 
 	manifest, err := s.getManifest(ctx.ImageStore)
 	if err != nil {
-		return nil, fmt.Errorf("get manifest: %v", err)
+		return nil, fmt.Errorf("get manifest: %s", err)
 	}
 
 	config, err := s.getConfig(manifest.Config, ctx.ImageStore)
 	if err != nil {
-		return nil, fmt.Errorf("get config: %v", err)
+		return nil, fmt.Errorf("get config: %s", err)
 	}
 
 	// Update in-memory map of merged stage vars from ARG and ENV.

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -172,7 +172,7 @@ func (cli *MakisuClient) readLines(body io.ReadCloser) error {
 		if err == io.EOF {
 			break
 		} else if err != nil {
-			return fmt.Errorf("failed to read build body: %v", err)
+			return fmt.Errorf("failed to read build body: %s", err)
 		}
 		cli.WorkerLog(string(line))
 		cli.maybeGetBuildCode(line, &buildCode)

--- a/lib/mountutils/mountutils.go
+++ b/lib/mountutils/mountutils.go
@@ -58,7 +58,7 @@ func (info *mountInfo) initialize() error {
 		log.Debug("Cannot init mountmanager, /proc/mounts does not exist")
 		return nil
 	} else if err != nil {
-		return fmt.Errorf("mountmanager initialize: %v", err)
+		return fmt.Errorf("mountmanager initialize: %s", err)
 	}
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
@@ -86,7 +86,7 @@ func (info *mountInfo) isMountpoint(filename string) (bool, error) {
 	var err error
 	info.init.Do(func() { err = info.initialize() })
 	if err != nil {
-		return false, fmt.Errorf("ismount: %v", err)
+		return false, fmt.Errorf("ismount: %s", err)
 	}
 	_, found := info.data[filename]
 	return found, nil

--- a/lib/parser/dockerfile/common.go
+++ b/lib/parser/dockerfile/common.go
@@ -23,12 +23,13 @@ import (
 )
 
 var (
-	errUnsupportedDirective = errors.New("Unsupported directive type")
 	errBeforeFirstFrom      = errors.New("Invalid directive before first build stage (FROM)")
-	errMissingArgs          = errors.New("Missing arguments")
 	errMalformedChown       = errors.New("Malformed chown argument")
 	errMalformedKeyVal      = errors.New("Malformed key/value pairs")
+	errMissingArgs          = errors.New("Missing arguments")
+	errMissingSpace         = errors.New("Missing space in single variable ENV")
 	errNotExactlyOneArg     = errors.New("Expected exactly one argument")
+	errUnsupportedDirective = errors.New("Unsupported directive type")
 )
 
 func parseFlag(s string, name string) (string, bool, error) {
@@ -64,7 +65,7 @@ type parseError struct {
 
 // Error returns a formatted error string.
 func (e *parseError) Error() string {
-	return fmt.Sprintf("failed to parse %s directive with args '%s': %s",
+	return fmt.Sprintf("failed to parse '%s' directive with args '%s': %s",
 		strings.ToUpper(e.t), e.args, e.msg)
 }
 

--- a/lib/parser/dockerfile/env.go
+++ b/lib/parser/dockerfile/env.go
@@ -15,12 +15,8 @@
 package dockerfile
 
 import (
-	"errors"
-	"fmt"
 	"strings"
 )
-
-var errMissingSpace = errors.New("Missing space in single value ENV")
 
 // EnvDirective represents the "ENV" dockerfile command.
 type EnvDirective struct {
@@ -41,10 +37,10 @@ func newEnvDirective(base *baseDirective, state *parsingState) (Directive, error
 		return &EnvDirective{base, vars}, nil
 	}
 
+	// Formatted as <key> <value>. Find index of space.
 	idx := strings.Index(base.Args, " ")
 	if idx == -1 || idx == len(base.Args)-1 {
-		err := fmt.Errorf("%s: '%s'", errMissingSpace, base.Args)
-		return nil, base.err(err)
+		return nil, base.err(errMissingSpace)
 	}
 
 	// Split on the 1st space (including whitespace characters).

--- a/lib/parser/dockerfile/parse_file.go
+++ b/lib/parser/dockerfile/parse_file.go
@@ -36,15 +36,15 @@ func ParseFile(filecontents string, args map[string]string) ([]*Stage, error) {
 	for scanner.Scan() {
 		count++
 		if err := scanner.Err(); err != nil {
-			return nil, fmt.Errorf("file scanning failed (line %d): %v", count, err)
+			return nil, fmt.Errorf("file scanning failed (line %d): %s", count, err)
 		}
 		text := scanner.Text()
 		if directive, err := newDirective(text, state); err != nil {
-			return nil, fmt.Errorf("failed to create new directive (line %d): %v", count, err)
+			return nil, fmt.Errorf("failed to create new directive (line %d): %s", count, err)
 		} else if directive == nil {
 			continue
 		} else if err := directive.update(state); err != nil {
-			return nil, fmt.Errorf("failed to update parser state (line %d): %v", count, err)
+			return nil, fmt.Errorf("failed to update parser state (line %d): %s", count, err)
 		}
 	}
 

--- a/lib/parser/dockerfile/stopsignal.go
+++ b/lib/parser/dockerfile/stopsignal.go
@@ -30,7 +30,7 @@ type StopsignalDirective struct {
 func newStopsignalDirective(base *baseDirective, state *parsingState) (Directive, error) {
 	signal, err := strconv.Atoi(base.Args)
 	if err != nil {
-		return nil, fmt.Errorf("signal must be integer: %v", err)
+		return nil, fmt.Errorf("signal must be integer: %s", err)
 	} else if signal < 0 {
 		return nil, fmt.Errorf("signal must be > 0: %v", signal)
 	}

--- a/lib/shell/cmd.go
+++ b/lib/shell/cmd.go
@@ -37,13 +37,13 @@ func ExecCommand(outStream, errStream func(string, ...interface{}), workingDir, 
 
 	go func() {
 		if err := readerToStream(outReader, outStream); err != nil {
-			outStream("Failed to stream stdout from command: %v\n", err)
+			outStream("Failed to stream stdout from command: %s\n", err)
 		}
 	}()
 
 	go func() {
 		if err := readerToStream(errReader, errStream); err != nil {
-			errStream("Failed to stream stderr from command: %v\n", err)
+			errStream("Failed to stream stderr from command: %s\n", err)
 		}
 	}()
 

--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -407,7 +407,7 @@ func (fs *MemFS) commitLayer(l *memLayer, w *tar.Writer) error {
 	if err := l.rangeFiles(func(f memFile) error {
 		return f.commit(w)
 	}); err != nil {
-		return fmt.Errorf("commit layer: %v", err)
+		return fmt.Errorf("commit layer: %s", err)
 	}
 	fs.layers = append(fs.layers, l)
 	return nil

--- a/lib/snapshot/utils.go
+++ b/lib/snapshot/utils.go
@@ -267,7 +267,7 @@ func walkLink(path, root string, linksWalked *int) (newpath string, islink bool,
 	}
 	fi, err := os.Lstat(filepath.Join(root, path))
 	if err != nil {
-		return "", false, fmt.Errorf("lstat: %v", err)
+		return "", false, fmt.Errorf("lstat: %s", err)
 	}
 	if fi.Mode()&os.ModeSymlink == 0 {
 		return path, false, nil
@@ -276,7 +276,7 @@ func walkLink(path, root string, linksWalked *int) (newpath string, islink bool,
 	if err != nil {
 		return "", false, err
 	} else if !filepath.HasPrefix(newpath, root) && filepath.IsAbs(newpath) {
-		return "", false, fmt.Errorf("link points outside of root: %v -> %v", filepath.Join(root, path), newpath)
+		return "", false, fmt.Errorf("link points outside of root: %s -> %s", filepath.Join(root, path), newpath)
 	}
 	*linksWalked++
 	newpath = strings.TrimPrefix(newpath, root)
@@ -288,7 +288,7 @@ func walkLinks(path, root string, linksWalked *int) (string, error) {
 	case dir == "":
 		newpath, _, err := walkLink(file, root, linksWalked)
 		if err != nil {
-			return newpath, fmt.Errorf("walk link: %v", err)
+			return newpath, fmt.Errorf("walk link: %s", err)
 		}
 		return newpath, nil
 	case file == "":
@@ -308,7 +308,7 @@ func walkLinks(path, root string, linksWalked *int) (string, error) {
 		}
 		newpath, islink, err := walkLink(filepath.Join(newdir, file), root, linksWalked)
 		if err != nil {
-			return "", fmt.Errorf("walk link: %v", err)
+			return "", fmt.Errorf("walk link: %s", err)
 		}
 		if !islink {
 			return newpath, nil

--- a/lib/tario/write.go
+++ b/lib/tario/write.go
@@ -27,7 +27,7 @@ import (
 // This function doesn't handle parent directories.
 func WriteEntry(w *tar.Writer, src string, h *tar.Header) error {
 	if err := WriteHeader(w, h); err != nil {
-		return fmt.Errorf("write header helper: %v", err)
+		return fmt.Errorf("write header helper: %s", err)
 	}
 
 	switch h.Typeflag {

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -161,11 +161,12 @@ func IsSpecialFile(fi os.FileInfo) bool {
 	return fi.Mode()&(os.ModeCharDevice|os.ModeDevice|os.ModeNamedPipe|os.ModeSocket) != 0
 }
 
-// FileInfoStat provides a convenience wrapper for casting the generic FileInfo.Sys field.
+// FileInfoStat provides a convenience wrapper for casting the generic
+// FileInfo.Sys field.
 func FileInfoStat(fi os.FileInfo) *syscall.Stat_t {
 	s, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		panic("failed to cast fileinfo.sys to stat_t")
+		panic("Failed to cast fileinfo.sys to stat_t")
 	}
 	return s
 }

--- a/test/python/image.py
+++ b/test/python/image.py
@@ -29,7 +29,7 @@ class DockerImage():
         exit_code = subprocess.call(command)
         if exit_code != 0:
             msg = 'Failed to extract docker image to local filesystem: {}'.format(
-                self.image_name, self.image_tar)
+                self.image_name)
             raise Exception(msg)
 
     def _load_manifest(self):
@@ -64,8 +64,10 @@ class DockerLayer():
             yield member
 
     def get_tar_header_count(self):
-        try: return len(list(self.get_tar_headers()))
-        except tarfile.ReadError: return 0
+        try:
+            return len(list(self.get_tar_headers()))
+        except tarfile.ReadError:
+            return 0
 
     def get_tar_header_by_name(self, name):
         for member in self.get_tar_headers():


### PR DESCRIPTION
Replace `fmt.Errorf("...%v", err)` with `fmt.Errorf("...%s", err)`;
Revert change to ENV parser error message, since it was duplicated.