### PR TITLE
Added alpine image for gitlab support

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,19 @@
+FROM golang:1.11 AS builder
+
+RUN mkdir -p /go/src/github.com/uber/makisu
+WORKDIR /go/src/github.com/uber/makisu
+
+ADD Makefile .
+RUN make ext-tools/Linux/dep
+
+ADD Gopkg.toml Gopkg.lock ./
+ADD .git ./.git
+ADD cli ./cli
+ADD bin ./bin
+ADD lib ./lib
+RUN make bins
+
+FROM alpine:3.6
+COPY --from=builder /go/src/github.com/uber/makisu/bin/makisu/makisu /makisu-internal/makisu
+ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
+ENTRYPOINT ["/makisu-internal/makisu"]

--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,16 @@ env: test/python/requirements.txt
 
 
 ### Target to build the makisu docker images.
-.PHONY: image publish
-image:
+.PHONY: images publish
+images:
 	docker build -t $(REGISTRY)/makisu:$(PACKAGE_VERSION) -f Dockerfile .
 	docker tag $(REGISTRY)/makisu:$(PACKAGE_VERSION) makisu:$(PACKAGE_VERSION)
+	docker build -t $(REGISTRY)/makisu-alpine:$(PACKAGE_VERSION) -f Dockerfile.alpine .
+	docker tag $(REGISTRY)/makisu-alpine:$(PACKAGE_VERSION) makisu-alpine:$(PACKAGE_VERSION)
 
-publish: image
+publish: images
 	docker push $(REGISTRY)/makisu:$(PACKAGE_VERSION)
+	docker push $(REGISTRY)/makisu-alpine:$(PACKAGE_VERSION)
 
 
 
@@ -117,14 +120,14 @@ cunit-test: $(ALL_SRC)
 		golang:$(GO_VERSION) \
 		-c "make ext-tools unit-test"
 
-integration: env image
+integration: env images
 	PACKAGE_VERSION=$(PACKAGE_VERSION) ./env/bin/py.test --maxfail=1 --durations=6 --timeout=300 -vv test/python
 
 
 
 ### Misc targets
 .PHONY: clean integration-single
-integration-single: env image
+integration-single: env images
 	PACKAGE_VERSION=$(PACKAGE_VERSION) ./env/bin/py.test test/python/test_build.py::$(TEST_NAME)
 
 

--- a/test/python/utils.py
+++ b/test/python/utils.py
@@ -64,6 +64,8 @@ def registry_ensure_image(image, registry):
 
 def get_base_image():
     version = os.getenv("PACKAGE_VERSION", "latest")
+    if os.getenv("MAKISU_ALPINE", "0") != "0":
+        return "makisu-alpine:{}".format(version)
     return "makisu:{}".format(version)
 
 


### PR DESCRIPTION
We clean up our filesystem before a build, so having an image with an alpine base should not impact correctness. To test that image run:
`MAKISU_ALPINE=1 make integration`