### PR TITLE
Change registry basic auth ping to use https

### DIFF
--- a/lib/registry/security/basicauth.go
+++ b/lib/registry/security/basicauth.go
@@ -61,7 +61,7 @@ func ping(addr string, tr http.RoundTripper) (challenge.Manager, error) {
 	resp, err := httputil.Send(
 		"GET",
 		fmt.Sprintf(basePingQuery, addr),
-		httputil.SendTransport(tr),
+		httputil.SendTLSTransport(tr),
 		httputil.SendAcceptedCodes(http.StatusOK, http.StatusUnauthorized),
 	)
 	if err != nil {


### PR DESCRIPTION
Address a basic auth issue with private gitlab registry https://github.com/uber/makisu/issues/106.

Before makisu relies on the registry to redirect to a https location on the first http ping request. This change enforces the first ping request to be https because some private registries does not have a http port. As basic authentication usually implies TLS, I think it makes more sense if the first ping request is using TLS too.