### PR TITLE
no need to blacklist /mnt

### DIFF
--- a/lib/pathutils/const.go
+++ b/lib/pathutils/const.go
@@ -19,11 +19,9 @@ var (
 	// copying directories around and computing filesystem diffs.
 	DefaultBlacklist = append([]string{
 		DefaultInternalDir,
-		// Found through experiments
-		"/dev",
+		// Found through experiments.
 		"/.dockerinit",
-		"/srv",
-		"/mnt",
+		"/dev",
 	}, dockerBlacklist...)
 
 	dockerBlacklist = []string{


### PR DESCRIPTION
I saw users actually try to create file under /mnt, and we shouldn't block that.