### PR TITLE
Added credential helper binaries in makisu images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,22 @@ ADD bin ./bin
 ADD lib ./lib
 RUN make lbins
 
+
+FROM golang:1.11 AS gcr_cred_helper_builder
+RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr
+RUN CGO_ENABLED=0 make -C /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr && \
+    cp /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr/bin/docker-credential-gcr /docker-credential-gcr
+
+
+FROM golang:1.11 AS ecr_cred_helper_builder
+RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
+
+
 FROM scratch
 COPY --from=builder /go/src/github.com/uber/makisu/bin/makisu/makisu.linux /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
+
+COPY --from=gcr_cred_helper_builder /docker-credential-gcr /makisu-internal/docker-credential-gcr
+COPY --from=ecr_cred_helper_builder /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /makisu-internal/docker-credential-ecr-login
 ENTRYPOINT ["/makisu-internal/makisu"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,7 +12,22 @@ ADD bin ./bin
 ADD lib ./lib
 RUN make bins
 
+
+FROM golang:1.11 AS gcr_cred_helper_builder
+RUN go get -u github.com/GoogleCloudPlatform/docker-credential-gcr
+RUN CGO_ENABLED=0 make -C /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr && \
+    cp /go/src/github.com/GoogleCloudPlatform/docker-credential-gcr/bin/docker-credential-gcr /docker-credential-gcr
+
+
+FROM golang:1.11 AS ecr_cred_helper_builder
+RUN go get -u github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login
+RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
+
+
 FROM alpine:3.6
 COPY --from=builder /go/src/github.com/uber/makisu/bin/makisu/makisu /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
+
+COPY --from=gcr_cred_helper_builder /docker-credential-gcr /makisu-internal/docker-credential-gcr
+COPY --from=ecr_cred_helper_builder /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /makisu-internal/docker-credential-ecr-login
 ENTRYPOINT ["/makisu-internal/makisu"]


### PR DESCRIPTION
We need those binaries in order to get the docker credentials to push to the registries. We considered using init containers, but it's clear that we should push that out to the future (when we split pull, build, push into separate phases/containers).