### PR TITLE
removed panics that mess up in k8s environments that use a random UID

### DIFF
--- a/lib/builder/step/fixtures.go
+++ b/lib/builder/step/fixtures.go
@@ -19,7 +19,6 @@ package step
 import (
 	"fmt"
 	"os"
-	"strconv"
 )
 
 var currUID int

--- a/lib/builder/step/fixtures.go
+++ b/lib/builder/step/fixtures.go
@@ -18,35 +18,17 @@ package step
 
 import (
 	"fmt"
-	"os/user"
+	"os"
 	"strconv"
 )
 
-var currUser string
 var currUID int
-var currGroup string
 var currGID int
 var validChown string
 
 func init() {
-	u, err := user.Current()
-	if err != nil {
-		panic(err)
-	}
-	currUID, err = strconv.Atoi(u.Uid)
-	if err != nil {
-		panic(err)
-	}
-	currUser = u.Name
-	g, err := user.LookupGroupId(u.Gid)
-	if err != nil {
-		panic(err)
-	}
-	currGID, err = strconv.Atoi(u.Gid)
-	if err != nil {
-		panic(err)
-	}
-	currGroup = g.Name
+	currUID = os.Geteuid()
+	currGID = os.Getegid()
 	validChown = fmt.Sprintf("%d:%d", currUID, currGID)
 }
 

--- a/lib/utils/utils.go
+++ b/lib/utils/utils.go
@@ -18,9 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/user"
 	"sort"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -173,19 +171,7 @@ func FileInfoStat(fi os.FileInfo) *syscall.Stat_t {
 
 // GetUIDGID returns the uid/gid pair for the current user.
 func GetUIDGID() (int, int, error) {
-	currUser, err := user.Current()
-	if err != nil {
-		return 0, 0, err
-	}
-	currUID, err := strconv.Atoi(currUser.Uid)
-	if err != nil {
-		return 0, 0, err
-	}
-	currGID, err := strconv.Atoi(currUser.Gid)
-	if err != nil {
-		return 0, 0, err
-	}
-	return currUID, currGID, nil
+	return os.Geteuid(), os.Getegid(), nil
 }
 
 // IsValidJSON returns true if the blob passed in is a valid json object.


### PR DESCRIPTION
I agree 100% with everything you said in #133 _in theory_, but you're not actually using the names, and other corporate environments have a different CI/CD setup than you do. What I've changed it to meets the MVP of the functions, passes all known tests, and works in kubernetes without having to play wack-a-mole to get `user.Current()` to work.