### PR TITLE
fix missing lib in alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -25,6 +25,8 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 
 
 FROM alpine:3.6
+RUN apk add --no-cache libc6-compat
+
 COPY --from=builder /go/src/github.com/uber/makisu/bin/makisu/makisu /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
 


### PR DESCRIPTION
Hello, 

Here's a small fix for "no such file or directory problem" when running makisu from the alpine image, looks like go net library still requires the libc package. 

```
docker run -ti --rm --entrypoint="" gcr.io/makisu-project/makisu-alpine:v0.1.7 /makisu-internal/makisu version
standard_init_linux.go:190: exec user process caused "no such file or directory"
```
After rebuilding image with this fix everything works again:
```
docker run -ti --rm --entrypoint="" makisu-alpine:v0.1.7-4-g1b35fe3 /makisu-internal/makisu version
v0.1.7-4-g1b35fe3
```
