### PR TITLE
Added ability to read certs from a directory

### DIFF
--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -78,6 +78,8 @@ To configure your own registry endpoint, pass a custom configuration file to Mak
         username: <username>
         password: <password>
 ```
+Note: For the cert path, you can point to a directory containing your certificates. Makisu will then use all of the certs in that
+directory for TLS verification.
 
 ## Cred helper
 

--- a/lib/fileio/utils.go
+++ b/lib/fileio/utils.go
@@ -15,8 +15,10 @@
 package fileio
 
 import (
+	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -34,4 +36,25 @@ func ReaderToFile(r io.Reader, dst string) error {
 		return fmt.Errorf("copy to file %s: %s", dst, err)
 	}
 	return nil
+}
+
+// ConcatDirectoryContents concatenates all regular files inside the source
+// directory and returns their concatenated contents.
+func ConcatDirectoryContents(sourceDir string) ([]byte, error) {
+	files, err := ioutil.ReadDir(sourceDir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %s", err)
+	}
+
+	output := bytes.Buffer{}
+	for _, fi := range files {
+		path := filepath.Join(sourceDir, fi.Name())
+		content, err := ioutil.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %s", path, err)
+		} else if _, err := output.Write(content); err != nil {
+			return nil, fmt.Errorf("write to buffer: %s", err)
+		}
+	}
+	return output.Bytes(), nil
 }

--- a/lib/fileio/utils_test.go
+++ b/lib/fileio/utils_test.go
@@ -13,6 +13,7 @@ func TestConcatDirectoryContents(t *testing.T) {
 	t.Run("no files", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "makisu-test")
 		require.NoError(t, err)
+		defer os.RemoveAll(dir)
 
 		contents, err := ConcatDirectoryContents(dir)
 		require.NoError(t, err)
@@ -22,6 +23,7 @@ func TestConcatDirectoryContents(t *testing.T) {
 	t.Run("some files", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "makisu-test")
 		require.NoError(t, err)
+		defer os.RemoveAll(dir)
 
 		f1 := filepath.Join(dir, "f1")
 		err = ioutil.WriteFile(f1, []byte("TEST1"), os.ModePerm)

--- a/lib/fileio/utils_test.go
+++ b/lib/fileio/utils_test.go
@@ -1,0 +1,38 @@
+package fileio
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcatDirectoryContents(t *testing.T) {
+	t.Run("no files", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "makisu-test")
+		require.NoError(t, err)
+
+		contents, err := ConcatDirectoryContents(dir)
+		require.NoError(t, err)
+		require.Len(t, contents, 0)
+	})
+
+	t.Run("some files", func(t *testing.T) {
+		dir, err := ioutil.TempDir("", "makisu-test")
+		require.NoError(t, err)
+
+		f1 := filepath.Join(dir, "f1")
+		err = ioutil.WriteFile(f1, []byte("TEST1"), os.ModePerm)
+		require.NoError(t, err)
+
+		f2 := filepath.Join(dir, "f2")
+		err = ioutil.WriteFile(f2, []byte("TEST2"), os.ModePerm)
+		require.NoError(t, err)
+
+		contents, err := ConcatDirectoryContents(dir)
+		require.NoError(t, err)
+		require.Equal(t, "TEST1TEST2", string(contents))
+	})
+}

--- a/lib/utils/httputil/tls.go
+++ b/lib/utils/httputil/tls.go
@@ -131,7 +131,7 @@ func parseCert(path string) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("concat cert dir contents: %s", err)
 		}
-		return certBytes, err
+		return certBytes, nil
 	}
 
 	certBytes, err := ioutil.ReadFile(path)

--- a/lib/utils/httputil/tls.go
+++ b/lib/utils/httputil/tls.go
@@ -22,7 +22,9 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"os"
 
+	"github.com/uber/makisu/lib/fileio"
 	"github.com/uber/makisu/lib/log"
 )
 
@@ -119,6 +121,19 @@ func createCertPool(paths ...string) (*x509.CertPool, error) {
 }
 
 func parseCert(path string) ([]byte, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("lstat path: %s", err)
+	}
+
+	if fi.IsDir() {
+		certBytes, err := fileio.ConcatDirectoryContents(path)
+		if err != nil {
+			return nil, fmt.Errorf("concat cert dir contents: %s", err)
+		}
+		return certBytes, err
+	}
+
 	certBytes, err := ioutil.ReadFile(path)
 	if err != nil {
 		return nil, fmt.Errorf("read file: %s", err)


### PR DESCRIPTION
We will want to support this at some point anyway, and this helps the mkrootfs tool work in native non-containerized linux.