### PR TITLE
Add support for password_file in Docker's AuthConfig

### DIFF
--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -18,7 +18,6 @@ package registry
 import (
 	"time"
 
-	"github.com/docker/engine-api/types"
 	"github.com/uber/makisu/lib/docker/image"
 	"github.com/uber/makisu/lib/registry/security"
 	"github.com/uber/makisu/lib/utils/httputil"
@@ -33,7 +32,7 @@ var ConfigurationMap = Map{
 var DefaultDockerHubConfiguration = Config{
 	Security: security.Config{
 		TLS:       &httputil.TLSConfig{},
-		BasicAuth: &types.AuthConfig{}, // DockerHub requires empty username and password for public repositories.
+		BasicAuth: &security.BasicAuthConfig{}, // DockerHub requires empty username and password for public repositories.
 	}}
 
 // Map contains a map of registry config.

--- a/lib/registry/security/security.go
+++ b/lib/registry/security/security.go
@@ -44,7 +44,7 @@ func (c *BasicAuthConfig) Get() (types.AuthConfig, error) {
 	if c.PasswordFile != "" {
 		password, err := ioutil.ReadFile(c.PasswordFile)
 		if err != nil {
-			return types.AuthConfig{}, fmt.Errorf("Read password file: %s", err)
+			return types.AuthConfig{}, fmt.Errorf("read password file: %s", err)
 		}
 		c.AuthConfig.Password = string(password)
 	}

--- a/lib/registry/security/security.go
+++ b/lib/registry/security/security.go
@@ -41,10 +41,8 @@ type BasicAuthConfig struct {
 
 // Get returns an AuthConfig.
 func (c *BasicAuthConfig) Get() (types.AuthConfig, error) {
-	var password []byte
-	var err error
 	if c.PasswordFile != "" {
-		password, err = ioutil.ReadFile(c.PasswordFile)
+		password, err := ioutil.ReadFile(c.PasswordFile)
 		if err != nil {
 			return types.AuthConfig{}, fmt.Errorf("Read password file: %s", err)
 		}

--- a/lib/registry/security/security.go
+++ b/lib/registry/security/security.go
@@ -48,8 +48,8 @@ func (c *BasicAuthConfig) Get() (types.AuthConfig, error) {
 		if err != nil {
 			return types.AuthConfig{}, fmt.Errorf("Read password file: %s", err)
 		}
+		c.AuthConfig.Password = string(password)
 	}
-	c.AuthConfig.Password = string(password)
 	return c.AuthConfig, nil
 }
 

--- a/lib/registry/security/security.go
+++ b/lib/registry/security/security.go
@@ -17,6 +17,7 @@ package security
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"path"
 
@@ -31,10 +32,31 @@ const tokenUsername = "<token>"
 
 var credentialHelperPrefix = path.Join(pathutils.DefaultInternalDir, "docker-credential-")
 
+// BasicAuthConfig is a simple wrapper of Docker's types.AuthConfig with addtional support
+// for a password file.
+type BasicAuthConfig struct {
+	types.AuthConfig
+	PasswordFile string `yaml:"password_file" json:"password_file"`
+}
+
+// Get returns an AuthConfig.
+func (c *BasicAuthConfig) Get() (types.AuthConfig, error) {
+	var password []byte
+	var err error
+	if c.PasswordFile != "" {
+		password, err = ioutil.ReadFile(c.PasswordFile)
+		if err != nil {
+			return types.AuthConfig{}, fmt.Errorf("Read password file: %s", err)
+		}
+	}
+	c.AuthConfig.Password = string(password)
+	return c.AuthConfig, nil
+}
+
 // Config contains tls and basic auth configuration.
 type Config struct {
 	TLS                    *httputil.TLSConfig `yaml:"tls"`
-	BasicAuth              *types.AuthConfig   `yaml:"basic"`
+	BasicAuth              *BasicAuthConfig    `yaml:"basic"`
 	RemoteCredentialsStore string              `yaml:"credsStore"`
 }
 
@@ -83,10 +105,13 @@ func (c Config) GetHTTPOption(addr, repo string) (httputil.SendOption, error) {
 
 func (c Config) getCredentials(helper, addr string) (types.AuthConfig, error) {
 	var authConfig types.AuthConfig
-	if c.BasicAuth != nil {
-		authConfig = *c.BasicAuth
-	}
 	var err error
+	if c.BasicAuth != nil {
+		authConfig, err = c.BasicAuth.Get()
+		if err != nil {
+			return types.AuthConfig{}, fmt.Errorf("get basic auth config: %s", err)
+		}
+	}
 	if helper != "" {
 		authConfig, err = c.getCredentialFromHelper(helper, addr)
 		if err != nil {
@@ -105,7 +130,10 @@ func (c Config) getCredentialFromHelper(helper, addr string) (types.AuthConfig, 
 
 	var ret types.AuthConfig
 	if c.BasicAuth != nil {
-		ret = *c.BasicAuth
+		ret, err = c.BasicAuth.Get()
+		if err != nil {
+			return types.AuthConfig{}, fmt.Errorf("get basic auth config: %s", err)
+		}
 	}
 	ret.ServerAddress = addr
 	if creds.Username == tokenUsername {


### PR DESCRIPTION
Docker's AuthConfig is not very convenient when you don't want to hardcode the password somewhere.

Tested with mkrootfs tool (very handy):
```
registry.ConfigurationMap["gcr.io"][".*"] = registry.Config{
		Security: security.Config{
			TLS: &httputil.TLSConfig{
				CA: httputil.X509Pair{
					Cert: httputil.Secret{
						Path: "$GOPATH/src/github.com/uber/makisu/assets/cacerts.pem",
					},
				},
			},
			BasicAuth: &security.BasicAuthConfig{
				types.AuthConfig{
					Username: "_json_key",
				},
				"$GOPATH/src/github.com/uber/makisu/key",
			},
		}}
```
```
$ tools/bin/mkrootfs/mkrootfs uber-infra-ext/uber-system/kraken-agent --registry=gcr.io --tag=sjc1-produ-0000000153 --dest /tmp/test1 --cacerts=assets/cacerts.pem
{"level":"info","ts":1548734938.131433,"caller":"log/logger.go:89","msg":"* Started pulling image gcr.io/uber-infra-ext/uber-system/kraken-agent:sjc1-produ-0000000153"}
{"level":"info","ts":1548734939.257889,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:2e8432f20ac578ef0bdfee678da567f0e458b6f0e5ef00bacadef5302999365c"}
{"level":"info","ts":1548734939.378516,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:c9d6247404a10162a8b78431fe3b4a3726eb9930a1fb39329c5ef66a31eef499"}
{"level":"info","ts":1548734939.3953059,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:68b174a1763dd356b45d3292c217ac1f6836dbe1f2d5a1318b69724642f414cc"}
{"level":"info","ts":1548734944.334476,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:68b174a1763dd356b45d3292c217ac1f6836dbe1f2d5a1318b69724642f414cc"}
{"level":"info","ts":1548734944.373534,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:bc6e19151f7ddf9a780c8a16037a89fd76ca6cfcd665cfdb7749141e0e94413d"}
{"level":"info","ts":1548734951.5959811,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:bc6e19151f7ddf9a780c8a16037a89fd76ca6cfcd665cfdb7749141e0e94413d"}
{"level":"info","ts":1548734951.633451,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:a5407316f1907f855402a132ae352fc7e38a3aff6d38792723b62d2ce6a1d13c"}
{"level":"info","ts":1548734997.913066,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:c9d6247404a10162a8b78431fe3b4a3726eb9930a1fb39329c5ef66a31eef499"}
{"level":"info","ts":1548734997.9534779,"caller":"log/logger.go:89","msg":"* Started pulling layer gcr.io/uber-infra-ext/uber-system/kraken-agent:sha256:6f410d1104f8f9175dd4977275088818e4de28883adffe04fd1b825f230452d9"}
{"level":"info","ts":1548734998.761594,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:6f410d1104f8f9175dd4977275088818e4de28883adffe04fd1b825f230452d9"}
{"level":"info","ts":1548735027.5902221,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:2e8432f20ac578ef0bdfee678da567f0e458b6f0e5ef00bacadef5302999365c"}
{"level":"info","ts":1548735044.722199,"caller":"log/logger.go:89","msg":"* Finished pulling layer uber-infra-ext/uber-system/kraken-agent:a5407316f1907f855402a132ae352fc7e38a3aff6d38792723b62d2ce6a1d13c"}
{"level":"info","ts":1548735044.723642,"caller":"log/logger.go:89","msg":"* Finished pulling image gcr.io/uber-infra-ext/uber-system/kraken-agent:sjc1-produ-0000000153 in 1m46.596395399s"}
```