### PR TITLE
Remove setting SSL_CERT_DIR in Makisu Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ RUN make -C /go/src/github.com/awslabs/amazon-ecr-credential-helper linux-amd64
 FROM scratch
 COPY --from=builder /go/src/github.com/uber/makisu/bin/makisu/makisu.linux /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
-ENV SSL_CERT_DIR=/makisu-internal/certs
 
 COPY --from=gcr_cred_helper_builder /docker-credential-gcr /makisu-internal/docker-credential-gcr
 COPY --from=ecr_cred_helper_builder /go/src/github.com/awslabs/amazon-ecr-credential-helper/bin/linux-amd64/docker-credential-ecr-login /makisu-internal/docker-credential-ecr-login

--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -102,4 +102,4 @@ Example GCR config:
       credsStore: gcr
 ```
 
-Note: for GCR, environment variable SSL_CERT_DIR is required. Makisu image set that to /makisu-internal/certs by default.
+Note: for GCR, environment variable SSL_CERT_DIR is required.


### PR DESCRIPTION
set default SSL_CERT_DIR in Dockerfile changes the default cert directory from /etc/ssl/certs to /makisu-internal/certs, which only contains a list of most common certs. I think as a result, all downloads get affected...

The correct use of /makisu-internal/certs is to append them to system certs (/etc/ssl/certs), which is what we do in makisu already.