### PR TITLE
Move defaults from config map to DockerRegistryClient

### DIFF
--- a/bin/makisu/cmd/pull.go
+++ b/bin/makisu/cmd/pull.go
@@ -29,9 +29,9 @@ type pullCmd struct {
 func getPullCmd() *pullCmd {
 	pullCmd := &pullCmd{
 		Command: &cobra.Command{
-			Use:                   "pull --dest <destination of rootfs> <image repository>",
+			Use: "pull --dest <destination of rootfs> <image repository>",
 			DisableFlagsInUseLine: true,
-			Short:                 "Pull docker image from registry into the storage directory of makisu.",
+			Short: "Pull docker image from registry into the storage directory of makisu.",
 		},
 	}
 	pullCmd.Args = func(cmd *cobra.Command, args []string) error {
@@ -61,7 +61,6 @@ func (cmd *pullCmd) Pull(repository string) {
 	registry.DefaultDockerHubConfiguration.Security.TLS.CA.Cert.Path = cmd.cacerts
 	registry.ConfigurationMap[image.DockerHubRegistry] = make(registry.RepositoryMap)
 	registry.ConfigurationMap[image.DockerHubRegistry]["library/*"] = registry.DefaultDockerHubConfiguration
-	registry.ConfigurationMap[image.DockerHubRegistry][".*"] = registry.DefaultDockerHubConfiguration
 
 	client := registry.New(store, cmd.registry, repository)
 	manifest, err := client.Pull(cmd.tag)

--- a/bin/makisu/cmd/utils.go
+++ b/bin/makisu/cmd/utils.go
@@ -42,8 +42,6 @@ import (
 
 func (cmd *buildCmd) initRegistryConfig() error {
 	if cmd.registryConfig == "" {
-		registry.ConfigurationMap[image.DockerHubRegistry] = make(registry.RepositoryMap)
-		registry.ConfigurationMap[image.DockerHubRegistry][".*"] = registry.DefaultDockerHubConfiguration
 		return nil
 	}
 

--- a/lib/registry/client.go
+++ b/lib/registry/client.go
@@ -82,6 +82,9 @@ func NewWithClient(store *storage.ImageStore, registry, repository string, clien
 
 func newClient(store *storage.ImageStore, registry, repository string, client *http.Client) *DockerRegistryClient {
 	config := Config{}
+	if registry == image.DockerHubRegistry {
+		config = DefaultDockerHubConfiguration
+	}
 	repoConfig, ok := ConfigurationMap[registry]
 	if ok {
 		for repo, c := range repoConfig {

--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -18,15 +18,12 @@ package registry
 import (
 	"time"
 
-	"github.com/uber/makisu/lib/docker/image"
 	"github.com/uber/makisu/lib/registry/security"
 	"github.com/uber/makisu/lib/utils/httputil"
 )
 
 // ConfigurationMap is a global variable that maps registry name to config.
-var ConfigurationMap = Map{
-	image.DockerHubRegistry: RepositoryMap{"library/*": DefaultDockerHubConfiguration},
-}
+var ConfigurationMap = Map{}
 
 // DefaultDockerHubConfiguration contains docker hub registry configuration.
 var DefaultDockerHubConfiguration = Config{

--- a/tools/bin/mkrootfs/main.go
+++ b/tools/bin/mkrootfs/main.go
@@ -26,7 +26,7 @@ var (
 
 func main() {
 	cmd := &cobra.Command{
-		Use:                   "--dest <destination of rootfs> <image repository>",
+		Use: "--dest <destination of rootfs> <image repository>",
 		DisableFlagsInUseLine: true,
 		Args: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
@@ -58,7 +58,6 @@ func pullAndExtract(registryURL, repository, tag, destination string) {
 	registry.DefaultDockerHubConfiguration.Security.TLS.CA.Cert.Path = cacerts
 	registry.ConfigurationMap[image.DockerHubRegistry] = make(registry.RepositoryMap)
 	registry.ConfigurationMap[image.DockerHubRegistry]["library/*"] = registry.DefaultDockerHubConfiguration
-	registry.ConfigurationMap[image.DockerHubRegistry][".*"] = registry.DefaultDockerHubConfiguration
 
 	client := registry.New(store, registryURL, repository)
 	manifest, err := client.Pull(tag)


### PR DESCRIPTION
We tried to be smart by adding a default configuration for library/*, but when both .* and library/* exist in the configuration map, there is no guarantee which comes first if the two regexes both match the repository. This is a fix by moving the default config for DockerHub to DockerRegistryClient.

A list of regex would have made more sense. We should migrate to that.