### PR TITLE
Fixed a workdir + env issue

### DIFF
--- a/lib/builder/step/workdir_step.go
+++ b/lib/builder/step/workdir_step.go
@@ -16,10 +16,12 @@ package step
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/uber/makisu/lib/context"
 	"github.com/uber/makisu/lib/docker/image"
+	"github.com/uber/makisu/lib/log"
 )
 
 // WorkdirStep implements BuildStep and execute WORKDIR directive
@@ -46,10 +48,12 @@ func (s *WorkdirStep) UpdateCtxAndConfig(
 	if err != nil {
 		return nil, fmt.Errorf("copy image config: %s", err)
 	}
-	if filepath.IsAbs(s.workingDir) {
+	log.Infof("WORKDIR: %s | %v", s.workingDir, filepath.IsAbs(s.workingDir))
+	workdir := os.ExpandEnv(s.workingDir)
+	if filepath.IsAbs(workdir) {
 		config.Config.WorkingDir = ctx.RootDir
 	}
-	config.Config.WorkingDir = filepath.Join(config.Config.WorkingDir, s.workingDir)
+	config.Config.WorkingDir = filepath.Join(config.Config.WorkingDir, workdir)
 
 	return config, nil
 }

--- a/testdata/build-context/go-with-debian-package/Dockerfile
+++ b/testdata/build-context/go-with-debian-package/Dockerfile
@@ -4,7 +4,9 @@ FROM $BASE_IMAGE AS phase1
 
 # Make sure that the variable gets expanded at some point in the command
 # execution process.
-RUN ls $HOME
+RUN mkdir $HOME/test
+WORKDIR $HOME
+RUN ls test
 
 RUN apt-get update
 

--- a/testdata/build-context/go-with-debian-package/Dockerfile
+++ b/testdata/build-context/go-with-debian-package/Dockerfile
@@ -1,6 +1,11 @@
 ARG BASE_IMAGE
 
 FROM $BASE_IMAGE AS phase1
+
+# Make sure that the variable gets expanded at some point in the command
+# execution process.
+RUN ls $HOME
+
 RUN apt-get update
 
 # Install runtime package


### PR DESCRIPTION
The following dockerfile would fail:
```
RUN mkdir $HOME/test
WORKDIR $HOME
RUN ls test
```
This was because we were not expanding the environment when processing the WORKDIR step.