### PR TITLE
Chowning symlinks properly

### DIFF
--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -660,6 +660,10 @@ func (fs *MemFS) untarSymlink(path string, header *tar.Header) error {
 	if err := os.Symlink(target, path); err != nil {
 		return fmt.Errorf("create symlink %s => %s: %s", path, target, err)
 	}
+
+	if err := os.Lchown(path, header.Uid, header.Gid); err != nil {
+		return fmt.Errorf("lchown symlink: %s", path)
+	}
 	return nil
 }
 
@@ -671,8 +675,7 @@ func (fs *MemFS) untarHardlink(path string, header *tar.Header) error {
 			"create link %s => %s: %s", path, target, err)
 	}
 	if err := tario.ApplyHeader(path, header); err != nil {
-		return fmt.Errorf(
-			"update hard link %s: %s", path, err)
+		return fmt.Errorf("update hard link %s: %s", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Turns out that neither us (nor Kaniko) chown our symlinks. This means that the permissions on the fs of the links themselves were wrong. If a non-root user created a symlink in the base image, that symlink would end up being owned by `root` after we untarred, and thus nothing executed as non-root would be able to remove or change those symlinks themselves.