### PR TITLE
Fixing parameter expansion bug in example shell function

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ function makisu_build() {
         -v /tmp/makisu-storage:/makisu-storage \
         gcr.io/makisu-project/makisu:$makisu_version build \
             --modifyfs=true --load \
-            ${@:1:-1} /makisu-context
+            ${@:1:${#@}-1} /makisu-context
     cd -
 }
 ```


### PR DESCRIPTION
The example appears to have assumed the `-1` in `${@:1:-1}` is a offset but it is in fact a length
  This resulted in the following error, `-bash: -1: substring expression < 0`
  This update has been tested on Mac OS X Mojave using Bash and Zsh