### PR TITLE
Updating release number in example to use most current docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build Dockerfiles that contain RUN, Makisu needs to run in a container.
 To try it locally, the following snippet can be placed inside your `~/.bashrc` or `~/.zshrc`:
 ```shell
 function makisu_build() {
-    makisu_version=${MAKISU_VERSION:-v0.1.8}
+    makisu_version=${MAKISU_VERSION:-v0.1.9}
     cd ${@: -1}
     docker run -i --rm --net host \
         -v /var/run/docker.sock:/docker.sock \


### PR DESCRIPTION
This updates the example to use the current Makisu docker image