### PR TITLE
Added support for native basic authentication to registry

### DIFF
--- a/lib/registry/security/basicauth.go
+++ b/lib/registry/security/basicauth.go
@@ -54,7 +54,8 @@ func BasicAuthTransport(addr, repo string, tr http.RoundTripper, authConfig type
 		ClientID:   "docker",
 		ForceOAuth: false, // Only support basic auth.
 	}
-	return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewTokenHandlerWithOptions(opts))), nil
+	basicAuth := defaultCredStore{authConfig}
+	return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewTokenHandlerWithOptions(opts), auth.NewBasicHandler(basicAuth))), nil
 }
 
 func ping(addr string, tr http.RoundTripper) (challenge.Manager, error) {


### PR DESCRIPTION
Hi, 
The docs mention that makisu can push/pull from registries having basic authentication, but I discovered that only token authentication was supported. 
I added basicAuth to the Authorizer so that it supports both authentication methods to docker registries. 