### PR TITLE
Fix authentication errors on AWS ECR

### DIFF
--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -83,8 +83,10 @@ directory for TLS verification.
 
 ## Cred helper
 
-Makisu images (>= 0.1.8) contains ECR and GCR cred helper binaries.
-To use them, plese pass in the environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY with corresponding registry config.
+Makisu images (>= 0.1.8) contains [ECR](https://github.com/awslabs/amazon-ecr-credential-helper) and [GCR](https://github.com/GoogleCloudPlatform/docker-credential-gcr) cred helper binaries.
+For ECR, you can export the following [variables](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) and you might need to export `AWS_SDK_LOAD_CONFIG=true`.
+
+If you encounter a certificate validation errors (ex: `x509: certificate signed by unknown authority`) you might want to export the following variable `SSL_CERT_DIR=/makisu-internal/certs/`.
 
 Example AWS ECR config:
 ```yaml
@@ -102,4 +104,4 @@ Example GCR config:
       credsStore: gcr
 ```
 
-Note: for GCR, environment variable SSL_CERT_DIR is required.
+NB: You need to put your config files (ex: aws config/credentials file) inside the /makisu-internal/ dir (and use env variable to specify their locations) in order for the helpers to find and use them when building your images.

--- a/lib/registry/client.go
+++ b/lib/registry/client.go
@@ -524,8 +524,10 @@ func (c DockerRegistryClient) pushOneLayerChunk(location string, start, endInclu
 		opt,
 		httputil.SendTimeout(c.config.Timeout),
 		c.config.sendRetry(),
-		// Docker registry returns 202 but gcr returns 204 on success.
-		httputil.SendAcceptedCodes(http.StatusAccepted, http.StatusNoContent),
+		// Docker registry returns 202
+		// GCR returns 204 on success
+		// AWS ECR returns 201 on success
+		httputil.SendAcceptedCodes(http.StatusAccepted, http.StatusNoContent, http.StatusCreated),
 		httputil.SendHeaders(headers),
 		httputil.SendBody(ratelimit.Reader(r, readerOptions)))
 	if err != nil {

--- a/lib/registry/security/basicauth.go
+++ b/lib/registry/security/basicauth.go
@@ -42,19 +42,25 @@ func BasicAuthTransport(addr, repo string, tr http.RoundTripper, authConfig type
 	if err != nil {
 		return nil, fmt.Errorf("ping v2 registry: %s", err)
 	}
-	opts := auth.TokenHandlerOptions{
-		Transport:   tr,
-		Credentials: defaultCredStore{authConfig},
-		Scopes: []auth.Scope{
-			auth.RepositoryScope{
-				Repository: repo,
-				Actions:    []string{"pull", "push"},
+	// This looks weird but when using AWS ECR (especially the docker ecr helper) we get a Username and a Password
+	// Then, the ping will create a challenge by parsing the www-authenticate header from the ECR server (it will return a "Basic ...")
+	// So if we use the `NewTokenHandlerWithOptions` we will always fail the Scheme checking in vendor/github.com/docker/distribution/registry/client/auth/session.go#L98 ("basic" != "bearer")
+	if authConfig.Username != "" && authConfig.Password != "" {
+		return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewBasicHandler(defaultCredStore{authConfig}))), nil
+	} else {
+		return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{
+			Transport:   tr,
+			Credentials: defaultCredStore{authConfig},
+			Scopes: []auth.Scope{
+				auth.RepositoryScope{
+					Repository: repo,
+					Actions:    []string{"pull", "push"},
+				},
 			},
-		},
-		ClientID:   "docker",
-		ForceOAuth: false, // Only support basic auth.
+			ClientID:   "docker",
+			ForceOAuth: false, // Only support basic auth.
+		}))), nil
 	}
-	return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewTokenHandlerWithOptions(opts))), nil
 }
 
 func ping(addr string, tr http.RoundTripper) (challenge.Manager, error) {


### PR DESCRIPTION
On AWS ECR we do need to use the Basic Authentication mechanism
because otherwise the scheme will be "bearer" (and not "basic)
and the check of vendor/github.com/docker/distribution/registry/client/auth/session.go#L98
will fail and no authentication header will be put in the request.

This will fix (#204)