### PR TITLE
Modified the Travis configuration file to enable automated FOSSA scans.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,9 @@ language: python
 services:
     - docker
 
+before_script:
+- "curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install.sh | sudo bash"
+
 script:
     - make cunit-test integration
+    - fossa


### PR DESCRIPTION
I'm from FOSSA and I'm working with the Uber OSPO to automate license scanning. In addition to the changes in this PR, we may also need to add an API key as an environmental variable in the build environment.