### PR TITLE
Only use basic auth on AWS, otherwise all the registries would fail authentication

### DIFF
--- a/lib/registry/security/basicauth.go
+++ b/lib/registry/security/basicauth.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -45,8 +46,7 @@ func BasicAuthTransport(addr, repo string, tr http.RoundTripper, authConfig type
 	// This looks weird but when using AWS ECR (especially the docker ecr helper) we get a Username and a Password
 	// Then, the ping will create a challenge by parsing the www-authenticate header from the ECR server (it will return a "Basic ...")
 	// So if we use the `NewTokenHandlerWithOptions` we will always fail the Scheme checking in vendor/github.com/docker/distribution/registry/client/auth/session.go#L98 ("basic" != "bearer")
-	// We also have a special case for index.docker.io because it does not support Basic Auth
-	if authConfig.Username != "" && authConfig.Password != "" && addr != "index.docker.io" {
+	if authConfig.Username != "" && authConfig.Password != "" && strings.HasSuffix(addr, "amazonaws.com") {
 		return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewBasicHandler(defaultCredStore{authConfig}))), nil
 	} else {
 		return transport.NewTransport(tr, auth.NewAuthorizer(cm, auth.NewTokenHandlerWithOptions(auth.TokenHandlerOptions{


### PR DESCRIPTION
Again, my change introduced too much error, it was a bad idea to assume that all registry implement basic auth, let's limit basic auth to aws and expand it if needs be.