### PR TITLE
Specify json names for all the `Config` fields

### DIFF
--- a/docs/REGISTRY.md
+++ b/docs/REGISTRY.md
@@ -92,6 +92,7 @@ Example AWS ECR config:
 ```yaml
 "someawsregistry":
   "my-project/*":
+    push_chunk: -1
     security:
       credsStore: ecr-login
 ```
@@ -100,8 +101,13 @@ Example GCR config:
 ```yaml
 "gcr.io":
   "my-project/*":
+    push_chunk: -1
     security:
       credsStore: gcr
 ```
 
 NB: You need to put your config files (ex: aws config/credentials file) inside the /makisu-internal/ dir (and use env variable to specify their locations) in order for the helpers to find and use them when building your images.
+
+## Handling `BLOB_UPLOAD_INVALID` and `BLOB_UPLOAD_UNKNOWN` errors
+
+If you encounter these errors when pushing your image to a registry, try to use the `push_chunk: -1` option (some registries, despite implementing registry v2 do not support chunked upload, ECR and GCR being one example).

--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -40,17 +40,17 @@ type RepositoryMap map[string]Config
 
 // Config contains docker registry client configuration.
 type Config struct {
-	Concurrency   int           `yaml:"concurrency"`
-	Timeout       time.Duration `yaml:"timeout"`
-	Retries       int           `yaml:"retries"`
-	RetryInterval time.Duration `yaml:"retry_interval"`
-	RetryBackoff  float64       `yaml:"retry_backoff"`
-	PushRate      float64       `yaml:"push_rate"`
+	Concurrency   int           `yaml:"concurrency" json:"concurrency"`
+	Timeout       time.Duration `yaml:"timeout" json:"timeout"`
+	Retries       int           `yaml:"retries" json:"retries"`
+	RetryInterval time.Duration `yaml:"retry_interval" json:"retry_interval"`
+	RetryBackoff  float64       `yaml:"retry_backoff" json:"retry_backoff"`
+	PushRate      float64       `yaml:"push_rate" json:"push_rate"`
 	// If not specify, a default chunk size will be used.
 	// Set it to -1 to turn off chunk upload.
 	// NOTE: gcr does not support chunked upload.
-	PushChunk int64           `yaml:"push_chunk"`
-	Security  security.Config `yaml:"security"`
+	PushChunk int64           `yaml:"push_chunk" json:"push_chunk"`
+	Security  security.Config `yaml:"security" json:"security"`
 }
 
 func (c Config) applyDefaults() Config {

--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -48,7 +48,7 @@ type Config struct {
 	PushRate      float64       `yaml:"push_rate" json:"push_rate"`
 	// If not specify, a default chunk size will be used.
 	// Set it to -1 to turn off chunk upload.
-	// NOTE: gcr does not support chunked upload.
+	// NOTE: gcr and ecr do not support chunked upload.
 	PushChunk int64           `yaml:"push_chunk" json:"push_chunk"`
 	Security  security.Config `yaml:"security" json:"security"`
 }


### PR DESCRIPTION
This should fix #224 that was caused by the `push_chunk` conf not
being Unmarshalled when using json conf