### PR TITLE
Adds ability to override ssl cert location with environment variable

### DIFF
--- a/lib/registry/security/security.go
+++ b/lib/registry/security/security.go
@@ -22,6 +22,7 @@ import (
 	"path"
 
 	"github.com/uber/makisu/lib/pathutils"
+	"github.com/uber/makisu/lib/utils"
 	"github.com/uber/makisu/lib/utils/httputil"
 
 	"github.com/docker/docker-credential-helpers/client"
@@ -64,7 +65,7 @@ func (c Config) ApplyDefaults() Config {
 		c.TLS = &httputil.TLSConfig{}
 	}
 	if c.TLS.CA.Cert.Path == "" {
-		c.TLS.CA.Cert.Path = pathutils.DefaultCACertsPath
+		c.TLS.CA.Cert.Path = utils.DefaultEnv("SSL_CERT_DIR", pathutils.DefaultCACertsPath)
 	}
 	return c
 }


### PR DESCRIPTION
This becomes useful when using `makisu` for other functionality such as `push` and `pull --extract` for instance.
Currently we have `--cacerts` flags in the commands themselves, but they do not extend to non-dockerhub registries.