### PR TITLE
Bump version to 0.1.10 everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ To build Dockerfiles that contain RUN, Makisu needs to run in a container.
 To try it locally, the following snippet can be placed inside your `~/.bashrc` or `~/.zshrc`:
 ```shell
 function makisu_build() {
-    makisu_version=${MAKISU_VERSION:-v0.1.9}
+    makisu_version=${MAKISU_VERSION:-v0.1.11}
     cd ${@: -1}
     docker run -i --rm --net host \
         -v /var/run/docker.sock:/docker.sock \

--- a/bin/makisu/README.md
+++ b/bin/makisu/README.md
@@ -38,5 +38,5 @@ Global Flags:
       --log-output string   The output file path for the logs. Set to "stdout" to output to stdout (default "stdout")
 
 $ makisu version
-v0.1.8
+v0.1.11
 ```

--- a/examples/k8s/github-job-template.yaml
+++ b/examples/k8s/github-job-template.yaml
@@ -19,7 +19,7 @@ spec:
           mountPath: /makisu-context
       containers:
       - name: makisu
-        image: gcr.io/makisu-project/makisu:v0.1.8
+        image: gcr.io/makisu-project/makisu:v0.1.11
         imagePullPolicy: IfNotPresent
         args:
         - build

--- a/examples/k8s/github-job.yaml
+++ b/examples/k8s/github-job.yaml
@@ -18,13 +18,13 @@ spec:
           mountPath: /makisu-context
       containers:
       - name: makisu
-        image: gcr.io/makisu-project/makisu:v0.1.8
+        image: gcr.io/makisu-project/makisu:v0.1.11
         imagePullPolicy: IfNotPresent
         args:
         - build
         - --push=gcr.io
         - --modifyfs=true
-        - -t=makisu-project/example-github:v0.1.8
+        - -t=makisu-project/example-github:v0.1.11
         - --registry-config=/registry-config/registry.yaml
         - /makisu-context
         volumeMounts:


### PR DESCRIPTION
The latest release is `0.1.10`, but the documentation and examples in some places still refer to `0.1.8`