### PR TITLE
Fixed checksumming when context dir changes

### DIFF
--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -197,9 +197,14 @@ func checksumPathContents(ctx *context.BuildContext, path string, fi os.FileInfo
 		return nil
 	}
 
-	trimmedPath := strings.TrimPrefix(path, ctx.ContextDir)
+	trimmedPath, err := filepath.Rel(ctx.ContextDir, path)
+	if err != nil {
+		return fmt.Errorf("write path is outside of context dir (%s,%s): %v",
+			ctx.ContextDir, path, err)
+	}
+
 	if _, err := checksum.Write([]byte(trimmedPath)); err != nil {
-		return fmt.Errorf("write path to checksum")
+		return fmt.Errorf("write path to checksum: %v", err)
 	}
 
 	// If it is a directory, just return after checksumming the dir name.

--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -158,7 +158,7 @@ func (s *addCopyStep) updateContextChecksum(ctx *context.BuildContext, checksum 
 			if err != nil {
 				return fmt.Errorf("prev error during walk: %s", err)
 			}
-			return checksumPathContents(path, fi, checksum)
+			return checksumPathContents(ctx, path, fi, checksum)
 		}); err != nil {
 			return fmt.Errorf("walk %s: %s", source, err)
 		}
@@ -188,7 +188,7 @@ func (s *addCopyStep) contextRootDir(ctx *context.BuildContext) string {
 	return ctx.ContextDir
 }
 
-func checksumPathContents(path string, fi os.FileInfo, checksum io.Writer) error {
+func checksumPathContents(ctx *context.BuildContext, path string, fi os.FileInfo, checksum io.Writer) error {
 	// Skip special files.
 	if utils.IsSpecialFile(fi) {
 		if fi.IsDir() {
@@ -197,7 +197,8 @@ func checksumPathContents(path string, fi os.FileInfo, checksum io.Writer) error
 		return nil
 	}
 
-	if _, err := checksum.Write([]byte(path)); err != nil {
+	trimmedPath := strings.TrimPrefix(path, ctx.ContextDir)
+	if _, err := checksum.Write([]byte(trimmedPath)); err != nil {
 		return fmt.Errorf("write path to checksum")
 	}
 


### PR DESCRIPTION
Right now, if the context is mounted at `/X/context` vs `/Y/context`, the cache IDs of ADD/COPY steps will change from 1 build to the other.
The cache ID of the ADD/COPY step should only depend on the contents of the files being added from the context, as well as the path of that file **relative to the context directory**.