### PR TITLE
set SSL_CERT_DIR to get gcr docker-credential-helper working

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,7 @@ RUN make lbins
 FROM scratch
 COPY --from=builder /workspace/github.com/uber/makisu/bin/makisu/makisu.linux /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
+# Required for embedded GCR docker-credential-helper to work correctly
+ENV SSL_CERT_DIR /makisu-internal/certs
 
 ENTRYPOINT ["/makisu-internal/makisu"]

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -17,5 +17,7 @@ RUN apk add --no-cache libc6-compat
 
 COPY --from=builder /workspace/github.com/uber/makisu/bin/makisu/makisu /makisu-internal/makisu
 ADD ./assets/cacerts.pem /makisu-internal/certs/cacerts.pem
+# Required for embedded GCR docker-credential-helper to work correctly
+ENV SSL_CERT_DIR /makisu-internal/certs
 
 ENTRYPOINT ["/makisu-internal/makisu"]


### PR DESCRIPTION
Adds SSL_CERT_DIR to the dockerfiles to make GCR credential helper working without extra work.

See also https://github.com/uber/makisu/issues/204#issuecomment-484111846

