### PR TITLE
Add Redis password argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Makisu caches docker image layers both locally and in docker registry (if --push
 
 For example, Redis can be setup as a distributed cache key-value store with this [Kubernetes job spec](examples/k8s/redis.yaml).
 Then connect Makisu to redis cache by passing `--redis-cache-addr=redis:6379` argument.
+If the Redis server is password-protected, use `--redis-cache-password=password` argument.
 Cache has a 7 day TTL by default, which can be configured with `--local-cache-ttl=7d` argument.
 
 For more options on cache, please see [documentation](docs/CACHE.md).

--- a/bin/makisu/README.md
+++ b/bin/makisu/README.md
@@ -20,6 +20,7 @@ Flags:
       --blacklist stringArray           Makisu will ignore all changes to these locations in the resulting docker images
       --local-cache-ttl duration        Time-To-Live for local cache (default 168h0m0s)
       --redis-cache-addr string         The address of a redis server for cacheID to layer sha mapping
+      --redis-cache-password string           The password of the Redis server, should match 'requirepass' in redis.conf
       --redis-cache-ttl duration        Time-To-Live for redis cache (default 168h0m0s)
       --http-cache-addr string          The address of the http server for cacheID to layer sha mapping
       --http-cache-header stringArray   Request header for http cache server. Format is "--http-cache-header <header>:<value>"

--- a/bin/makisu/cmd/build.go
+++ b/bin/makisu/cmd/build.go
@@ -51,11 +51,12 @@ type buildCmd struct {
 	commit        string
 	blacklists    []string
 
-	localCacheTTL     time.Duration
-	redisCacheAddress string
-	redisCacheTTL     time.Duration
-	httpCacheAddress  string
-	httpCacheHeaders  []string
+	localCacheTTL      time.Duration
+	redisCacheAddress  string
+	redisCachePassword string
+	redisCacheTTL      time.Duration
+	httpCacheAddress   string
+	httpCacheHeaders   []string
 
 	dockerHost    string
 	dockerVersion string
@@ -109,6 +110,7 @@ func getBuildCmd() *buildCmd {
 
 	buildCmd.PersistentFlags().DurationVar(&buildCmd.localCacheTTL, "local-cache-ttl", time.Hour*168, "Time-To-Live for local cache")
 	buildCmd.PersistentFlags().StringVar(&buildCmd.redisCacheAddress, "redis-cache-addr", "", "The address of a redis server for cacheID to layer sha mapping")
+	buildCmd.PersistentFlags().StringVar(&buildCmd.redisCachePassword, "redis-cache-password", "", "The password of the Redis server, should match 'requirepass' in redis.conf")
 	buildCmd.PersistentFlags().DurationVar(&buildCmd.redisCacheTTL, "redis-cache-ttl", time.Hour*168, "Time-To-Live for redis cache")
 	buildCmd.PersistentFlags().StringVar(&buildCmd.httpCacheAddress, "http-cache-addr", "", "The address of the http server for cacheID to layer sha mapping")
 	buildCmd.PersistentFlags().StringArrayVar(&buildCmd.httpCacheHeaders, "http-cache-header", nil, "Request header for http cache server. Format is \"--http-cache-header <header>:<value>\"")

--- a/bin/makisu/cmd/utils.go
+++ b/bin/makisu/cmd/utils.go
@@ -169,7 +169,7 @@ func (cmd *buildCmd) newCacheManager(buildContext *context.BuildContext, imageNa
 	if cmd.redisCacheAddress != "" {
 		log.Infof("Using redis at %s for cacheID storage", cmd.redisCacheAddress)
 
-		kvStore, err = keyvalue.NewRedisStore(cmd.redisCacheAddress, cmd.redisCacheTTL)
+		kvStore, err = keyvalue.NewRedisStore(cmd.redisCacheAddress, cmd.redisCachePassword, cmd.redisCacheTTL)
 		if err != nil {
 			log.Errorf("Failed to connect to redis store: %s", err)
 		}

--- a/docs/CACHE.md
+++ b/docs/CACHE.md
@@ -21,6 +21,7 @@ To disable it, set ttl to 0s.
 To configure redis cache, use the following options:
 ```
 --redis-cache-addr string         The address of a redis server for cacheID to layer sha mapping
+--redis-cache-password string           The password of the Redis server, should match 'requirepass' in redis.conf
 --redis-cache-ttl duration        Time-To-Live for redis cache (default 168h0m0s)
 ```
 

--- a/lib/cache/keyvalue/redis_store.go
+++ b/lib/cache/keyvalue/redis_store.go
@@ -36,13 +36,14 @@ type redisStore struct {
 // NewRedisStore returns a new instance of Store backed by a redis server.
 // In this constructor we try to open a connection to redis. If that attempt fails
 // we return an error. If it succeeds we just close that connection.
-func NewRedisStore(addr string, ttl time.Duration) (Store, error) {
+func NewRedisStore(addr, password string, ttl time.Duration) (Store, error) {
 	cli := redis.NewClient(&redis.Options{
 		Addr:         addr,
 		MaxRetries:   MaxRetires,
 		DialTimeout:  DialTimeout,
 		ReadTimeout:  ReadTimeout,
 		WriteTimeout: WriteTimeout,
+		Password:     password,
 	})
 	if _, err := cli.Ping().Result(); err != nil {
 		return nil, err


### PR DESCRIPTION
Using [password](https://github.com/go-redis/redis/blob/master/options.go#L45) in `github.com/go-redis/redis` package to support password-protected Redis.