### PR TITLE
Partially cleanup COPY --from=<image> logic

### DIFF
--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -195,11 +195,11 @@ func (plan *BuildPlan) executeStage(stage *buildStage, lastStage, copiedFrom boo
 				return fmt.Errorf("build stage %s: %s", stage.alias, err)
 			}
 
-			if err := stage.checkpoint(plan.copyFromDirs[alias]); err != nil {
+			if err := remoteImageStage.checkpoint(plan.copyFromDirs[alias]); err != nil {
 				return fmt.Errorf("checkpoint stage %s: %s", stage.alias, err)
 			}
 
-			if err := stage.cleanup(); err != nil {
+			if err := remoteImageStage.cleanup(); err != nil {
 				return fmt.Errorf("cleanup stage %s: %s", stage.alias, err)
 			}
 		}

--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -51,7 +51,7 @@ func NewBuildPlan(
 	ctx *context.BuildContext, target image.Name, replicas []image.Name, cacheMgr cache.Manager,
 	parsedStages []*dockerfile.Stage, allowModifyFS, forceCommit bool) (*BuildPlan, error) {
 
-	aliases, err := buildAliases(parsedStages)
+	aliases, err := c(parsedStages)
 	if err != nil {
 		return nil, fmt.Errorf("build alias list: %s", err)
 	}
@@ -86,7 +86,7 @@ func NewBuildPlan(
 		plan.stages[i] = stage
 	}
 
-	if err := plan.handleCopyFromDirs(aliases); err != nil {
+	if err := plan.handleCopyFromDirs(); err != nil {
 		return nil, fmt.Errorf("handle cross refs: %s", err)
 	}
 
@@ -95,7 +95,7 @@ func NewBuildPlan(
 
 // handleCopyFromDirs goes through all of the stages in the build plan and looks
 // at the `COPY --from` steps to make sure they are valid.
-func (plan *BuildPlan) handleCopyFromDirs(aliases map[string]struct{}) error {
+func (plan *BuildPlan) handleCopyFromDirs() error {
 	for _, stage := range plan.stages {
 		for alias, dirs := range stage.copyFromDirs {
 			plan.copyFromDirs[alias] = stringset.FromSlice(

--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -40,6 +40,11 @@ type BuildPlan struct {
 	replicas     []image.Name
 	cacheMgr     cache.Manager
 	stages       []*buildStage
+
+	// Aliases of stages. For stages missing `AS`, an index number will be used
+	// as alias.
+	// Note: this doesn't include those `COPY --from=<alias>` if that alias is
+	// name of another image.
 	stageAliases map[string]struct{}
 
 	opts *buildPlanOptions

--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -51,7 +51,7 @@ func NewBuildPlan(
 	ctx *context.BuildContext, target image.Name, replicas []image.Name, cacheMgr cache.Manager,
 	parsedStages []*dockerfile.Stage, allowModifyFS, forceCommit bool) (*BuildPlan, error) {
 
-	aliases, err := c(parsedStages)
+	aliases, err := buildAliases(parsedStages)
 	if err != nil {
 		return nil, fmt.Errorf("build alias list: %s", err)
 	}

--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -175,7 +175,7 @@ func (plan *BuildPlan) Execute() (*image.DistributionManifest, error) {
 
 func (plan *BuildPlan) executeStage(stage *buildStage, lastStage, copiedFrom bool) error {
 	// Handle `COPY --from=<alias>` where alias is not a stage but an image.
-	// Create and execute an fake stage with only FROM. This case will not work
+	// Create and execute a fake stage with only FROM. This case will not work
 	// if modifyfs is set to false, but that combination was rejected in
 	// NewPlan().
 	// TODO: This should be done at step level.

--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -111,8 +111,8 @@ func (s *addCopyStep) SetCacheID(ctx *context.BuildContext, seed string) error {
 			return fmt.Errorf("hash copy directive: %s", err)
 		}
 
-		// If the step args and the contents of sources are identical,
-		// we should be able to use the cache from the previous build.
+		// If the step args and the contents of sources are identical, we should
+		// be able to use the cache from the previous build.
 		if err := s.updateContextChecksum(ctx, checksum); err != nil {
 			return fmt.Errorf("hash context sources: %s", err)
 		}
@@ -149,7 +149,8 @@ func (s *addCopyStep) Execute(ctx *context.BuildContext, modifyFS bool) (err err
 	return nil
 }
 
-// Updates the checksum passed in with the data stored in the context on the filesystem.
+// Updates the checksum passed in with the data stored in the context on the
+// filesystem.
 func (s *addCopyStep) updateContextChecksum(ctx *context.BuildContext, checksum io.Writer) error {
 	if s.fromStage != "" {
 		return fmt.Errorf("not supported: the copy step has from stage flag")

--- a/lib/builder/step/common.go
+++ b/lib/builder/step/common.go
@@ -62,7 +62,8 @@ func tarAndGzipDiffs(ctx *context.BuildContext, writeDiffs func(*tar.Writer) err
 	return gzipDigester, tarDigester, tempGzipTar.Name(), nil
 }
 
-// commitLayer commits a layer by either scan or copy operations, depending on the context.
+// commitLayer commits a layer by either scan or copy operations, depending on
+// the context.
 func commitLayer(ctx *context.BuildContext) ([]*image.DigestPair, error) {
 	var writeDiffs func(w *tar.Writer) error
 	if ctx.MustScan {

--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -88,6 +88,10 @@ func (fs *MemFS) Reset() {
 
 // Checkpoint relocates the given src files & directories to the given newRoot.
 func (fs *MemFS) Checkpoint(newRoot string, sources []string) error {
+	if len(sources) == 0 {
+		return nil
+	}
+
 	resolvedSources := []string{}
 	for _, src := range sources {
 		if matches, err := filepath.Glob(src); err != nil || len(matches) == 0 {

--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -258,8 +258,8 @@ func (fs *MemFS) AddLayerByScan(w *tar.Writer) error {
 
 // AddLayerByCopyOps creates an in-memory layer by performing copy operations
 // on the given src-dst pairs. The file system is not modified during this
-// operation. The resulting layer is merged in memory and written to the
-// tar writer.
+// operation. The resulting layer is merged in memory and written to the tar
+// writer.
 func (fs *MemFS) AddLayerByCopyOps(cs []*CopyOperation, w *tar.Writer) error {
 	fs.sync()
 	l := newMemLayer()


### PR DESCRIPTION
So stage initialization and execution can be sequentialized. Needed for future cache logic changes.

TODO: handleCopyFromDirs is not sequential yet.