### PR TITLE
Set seed cache ID for remote stage

### DIFF
--- a/lib/builder/build_plan.go
+++ b/lib/builder/build_plan.go
@@ -192,6 +192,7 @@ func (plan *BuildPlan) executeStage(stage *buildStage, lastStage, copiedFrom boo
 	// Handle `COPY --from=<alias>` where alias is not a stage but an image.
 	// Create and execute a fake stage with only FROM.
 	// TODO: This should be done at step level.
+	// TODO: This step prints `* Step 1/1 ...` which is misleading.
 	for alias, _ := range stage.copyFromDirs {
 		if _, ok := plan.stageAliases[alias]; !ok {
 			name, err := image.ParseNameForPull(alias)

--- a/lib/builder/build_stage.go
+++ b/lib/builder/build_stage.go
@@ -92,6 +92,11 @@ func newRemoteImageStage(
 	if err != nil {
 		return nil, fmt.Errorf("new from step: %s", err)
 	}
+	checksum := crc32.ChecksumIEEE([]byte(utils.BuildHash + fmt.Sprintf("%v", *planOpts)))
+	seed := fmt.Sprintf("%x", checksum)
+	if err := from.SetCacheID(ctx, seed); err != nil {
+		return nil, fmt.Errorf("set cache id: %s", err)
+	}
 	steps := []step.BuildStep{from}
 
 	// Set forceCommit to false.


### PR DESCRIPTION
Cache ID for these temp stages serves no purpose at the moment, but will be needed for a cleaner #72 fix 