### PR TITLE
Allow symlinks that use absolute path within the memfs/tar.

### DIFF
--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -577,12 +577,11 @@ func (fs *MemFS) untarOneItem(path string, header *tar.Header, r *tar.Reader) er
 			if err != nil {
 				return fmt.Errorf("read link %s: %s", linkTarget, err)
 			}
-
-			if filepath.IsAbs(linkTarget) {
-				linkTarget, err = pathutils.TrimRoot(linkTarget, fs.tree.src)
-				if err != nil {
-					return fmt.Errorf("trim link %s: %s", linkTarget, err)
-				}
+			if  filepath.IsAbs(linkTarget) && strings.HasPrefix(linkTarget, fs.tree.src) {
+			        linkTarget, err = pathutils.TrimRoot(linkTarget, fs.tree.src)
+                                if err != nil {
+                                        return fmt.Errorf("trim link %s: %s", linkTarget, err)
+                                }
 			}
 		}
 		localHeader, err := tar.FileInfoHeader(localInfo, linkTarget)

--- a/lib/snapshot/mem_fs_test.go
+++ b/lib/snapshot/mem_fs_test.go
@@ -68,6 +68,8 @@ func TestUntarFromPath(t *testing.T) {
 	require.NoError(err)
 	err = os.Mkdir(filepath.Join(tmpRoot, "mydir"), os.ModePerm)
 	require.NoError(err)
+	err = os.Symlink(filepath.Join("/test1", "test1.txt"), filepath.Join(tmpRoot, "test1", "abs_symlink.txt"))
+	require.NoError(err)
 
 	clk := clock.NewMock()
 	fs, err := NewMemFS(clk, tmpRoot, pathutils.DefaultBlacklist)


### PR DESCRIPTION
Fixes case where /home/rihan/bar/etc/alternatives/pager is symlinked to /bin/more. Without this change TrimRoot fails when it tries to trim fs.tree.src from linkTarget.