### PR TITLE
Revert "Untar: Fixing symlink untarring in memfs (#288)"

### DIFF
--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -659,6 +659,9 @@ func (fs *MemFS) untarDirectory(path string, header *tar.Header) error {
 // untarSymlink creates the symlink specified by header at path.
 func (fs *MemFS) untarSymlink(path string, header *tar.Header) error {
 	target := header.Linkname
+	if filepath.IsAbs(header.Linkname) {
+		target = filepath.Join(fs.tree.src, target)
+	}
 	if err := os.Symlink(target, path); err != nil {
 		return fmt.Errorf("create symlink %s => %s: %s", path, target, err)
 	}

--- a/lib/snapshot/mem_fs_test.go
+++ b/lib/snapshot/mem_fs_test.go
@@ -89,9 +89,9 @@ func TestUntarFromPath(t *testing.T) {
 	require.NoError(err)
 	require.False(fi.IsDir())
 
-	target, err := os.Readlink(filepath.Join(tmpRoot, "mydir"))
+	contents, err = ioutil.ReadFile(filepath.Join(tmpRoot, "mydir"))
 	require.NoError(err)
-	require.Equal("/target.txt", target)
+	require.Equal([]byte("TARGET"), contents)
 
 	require.Equal(7, fs.layers[len(fs.layers)-1].count())
 


### PR DESCRIPTION
This reverts commit c28fc3a57c2ff71a3da9275e6a7c1bb728810e0c.

#288 caused a few new issues with symlinks, and i don't think it's the right fix for the extract problem.