### PR TITLE
Revert "Make ADD untar tar.gz files (#309)"

### DIFF
--- a/lib/builder/step/add_copy_step.go
+++ b/lib/builder/step/add_copy_step.go
@@ -58,13 +58,12 @@ type addCopyStep struct {
 	toPath        string
 	chown         string
 	preserveOwner bool
-	isAdd         bool
 }
 
 // newAddCopyStep returns a BuildStep from given arguments.
 func newAddCopyStep(
 	directive Directive, args, chown, fromStage string,
-	fromPaths []string, toPath string, commit, preserveOwner, isAdd bool) (*addCopyStep, error) {
+	fromPaths []string, toPath string, commit, preserveOwner bool) (*addCopyStep, error) {
 
 	toPath = strings.Trim(toPath, "\"'")
 	for i := range fromPaths {
@@ -81,7 +80,6 @@ func newAddCopyStep(
 		toPath:        toPath,
 		chown:         chown,
 		preserveOwner: preserveOwner,
-		isAdd:         isAdd,
 	}, nil
 }
 
@@ -138,16 +136,14 @@ func (s *addCopyStep) Execute(ctx *context.BuildContext, modifyFS bool) (err err
 
 	internal := s.fromStage != ""
 	blacklist := append(pathutils.DefaultBlacklist, ctx.ImageStore.RootDir)
-	copyOp, err := snapshot.NewCopyOperation(relPaths, sourceRoot, s.workingDir, s.toPath, s.chown,
-		s.preserveOwner, internal, blacklist, s.isAdd)
+	copyOp, err := snapshot.NewCopyOperation(
+		relPaths, sourceRoot, s.workingDir, s.toPath, s.chown, blacklist, internal, s.preserveOwner)
 	if err != nil {
 		return fmt.Errorf("invalid copy operation: %s", err)
 	}
 
 	ctx.CopyOps = append(ctx.CopyOps, copyOp)
 	if modifyFS {
-		// Note: We still want to keep this copyop in the list, just in case there
-		// is no RUN afterwards, and layer needs to be created from copyops.
 		return copyOp.Execute()
 	}
 	return nil

--- a/lib/builder/step/add_copy_step_test.go
+++ b/lib/builder/step/add_copy_step_test.go
@@ -24,21 +24,21 @@ func TestContextDirs(t *testing.T) {
 	require := require.New(t)
 
 	srcs := []string{}
-	ac, err := newAddCopyStep(Copy, "", "", "", srcs, "", false, false, false)
+	ac, err := newAddCopyStep(Copy, "", "", "", srcs, "", false, false)
 	require.NoError(err)
 	stage, paths := ac.ContextDirs()
 	require.Equal("", stage)
 	require.Len(paths, 0)
 
 	srcs = []string{"src"}
-	ac, err = newAddCopyStep(Copy, "", "", "", srcs, "", false, false, false)
+	ac, err = newAddCopyStep(Copy, "", "", "", srcs, "", false, false)
 	require.NoError(err)
 	stage, paths = ac.ContextDirs()
 	require.Equal("", stage)
 	require.Len(paths, 0)
 
 	srcs = []string{"src"}
-	ac, err = newAddCopyStep(Copy, "", "", "stage", srcs, "", false, false, false)
+	ac, err = newAddCopyStep(Copy, "", "", "stage", srcs, "", false, false)
 	require.NoError(err)
 	stage, paths = ac.ContextDirs()
 	require.Equal("stage", stage)
@@ -48,7 +48,7 @@ func TestContextDirs(t *testing.T) {
 func TestTrimmingPaths(t *testing.T) {
 	require := require.New(t)
 
-	ac, err := newAddCopyStep(Copy, "", "", "", []string{"\"/from/path\""}, "\"/to/path\"", false, false, false)
+	ac, err := newAddCopyStep(Copy, "", "", "", []string{"\"/from/path\""}, "\"/to/path\"", false, false)
 	require.NoError(err)
 
 	require.Equal("/from/path", ac.fromPaths[0])

--- a/lib/builder/step/add_step.go
+++ b/lib/builder/step/add_step.go
@@ -23,8 +23,7 @@ type AddStep struct {
 
 // NewAddStep creates a new AddStep
 func NewAddStep(args, chown string, fromPaths []string, toPath string, commit, preserverOwner bool) (*AddStep, error) {
-	s, err := newAddCopyStep(
-		Add, args, chown, "", fromPaths, toPath, commit, preserverOwner, true)
+	s, err := newAddCopyStep(Add, args, chown, "", fromPaths, toPath, commit, preserverOwner)
 	if err != nil {
 		return nil, fmt.Errorf("new add/copy step: %s", err)
 	}

--- a/lib/builder/step/copy_step.go
+++ b/lib/builder/step/copy_step.go
@@ -26,8 +26,7 @@ func NewCopyStep(
 	args, chown, fromStage string, fromPaths []string, toPath string, commit, preserveOwner bool,
 ) (*CopyStep, error) {
 
-	s, err := newAddCopyStep(
-		Copy, args, chown, fromStage, fromPaths, toPath, commit, preserveOwner, false)
+	s, err := newAddCopyStep(Copy, args, chown, fromStage, fromPaths, toPath, commit, preserveOwner)
 	if err != nil {
 		return nil, fmt.Errorf("new add/copy step: %s", err)
 	}

--- a/lib/snapshot/copy_op.go
+++ b/lib/snapshot/copy_op.go
@@ -22,10 +22,10 @@ import (
 
 	"github.com/uber/makisu/lib/fileio"
 	"github.com/uber/makisu/lib/pathutils"
-	"github.com/uber/makisu/lib/tario"
 	"github.com/uber/makisu/lib/utils"
 )
 
+// CopyOperation defines a copy operation that occurred to generate a layer from.
 type CopyOperation struct {
 	srcRoot       string
 	srcs          []string
@@ -34,20 +34,16 @@ type CopyOperation struct {
 	gid           int
 	preserveOwner bool
 
-	// Indicates if the copy op is used for copying from previous stages.
-	// Blacklist is ignored in that case.
-	internal  bool
 	blacklist []string
-
-	// Set to true if the copy op was created by ADD step.
-	// Some functionalities are only available to ADD.
-	fromAdd bool
+	// Indicates if the copy op is used for copying from previous stages.
+	internal bool
 }
 
 // NewCopyOperation initializes and validates a CopyOperation. Use "internal" to
 // specify if the copy op is used for copying from previous stages.
-func NewCopyOperation(srcs []string, srcRoot, workDir, dst, chown string,
-	preserveOwner, internal bool, blacklist []string, fromAdd bool) (*CopyOperation, error) {
+func NewCopyOperation(
+	srcs []string, srcRoot, workDir, dst, chown string,
+	blacklist []string, internal, preserveOwner bool) (*CopyOperation, error) {
 
 	if err := checkCopyParams(srcs, workDir, dst); err != nil {
 		return nil, fmt.Errorf("check copy param: %s", err)
@@ -74,7 +70,6 @@ func NewCopyOperation(srcs []string, srcRoot, workDir, dst, chown string,
 		preserveOwner: preserveOwner,
 		blacklist:     blacklist,
 		internal:      internal,
-		fromAdd:       fromAdd,
 	}, nil
 }
 
@@ -91,32 +86,6 @@ func (c *CopyOperation) Execute() error {
 		if err != nil {
 			return fmt.Errorf("lstat %s: %s", src, err)
 		}
-
-		if strings.HasSuffix(src, ".tar.gz") && c.fromAdd {
-			// Special feature for ADD - Extract tar.gz into dst directory.
-			// If dst is an existing directory, untar.
-			// If dst doesn't exist, create it with root.
-			// If dst exists and is not a directory, fail.
-			reader, err := os.Open(src)
-			if err != nil {
-				return fmt.Errorf("open tar file: %s", err)
-			}
-			defer reader.Close()
-
-			if err := os.MkdirAll(c.dst, 0755); err != nil {
-				return fmt.Errorf("create/validate untar dst: %s", err)
-			}
-
-			gzipReader, err := tario.NewGzipReader(reader)
-			if err != nil {
-				return fmt.Errorf("unzip gz %s: %s", src, err)
-			}
-			if err := tario.Untar(gzipReader, c.dst); err != nil {
-				return fmt.Errorf("untar %s to dst %s: %s", src, c.dst, err)
-			}
-			return nil
-		}
-
 		var copier fileio.Copier
 		if c.internal {
 			copier = fileio.NewInternalCopier()
@@ -146,6 +115,7 @@ func (c *CopyOperation) Execute() error {
 					return fmt.Errorf("copy file %s to dir %s: %s", src, targetFilePath, err)
 				}
 			}
+
 		} else {
 			// File to file
 			if c.preserveOwner {

--- a/lib/snapshot/mem_fs_test.go
+++ b/lib/snapshot/mem_fs_test.go
@@ -710,7 +710,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/test2/test.txt"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -750,7 +750,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -792,7 +792,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -839,7 +839,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -887,7 +887,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -945,7 +945,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := ""
 		dst := "/dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -1003,7 +1003,7 @@ func TestCreateLayerByCopy(t *testing.T) {
 		workDir := "/wrk"
 		dst := "dst/"
 		c, err := NewCopyOperation(
-			srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+			srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 		require.NoError(err)
 		err = fs.addToLayer(newMemLayer(), c)
 		require.NoError(err)
@@ -1159,7 +1159,7 @@ func TestAddLayersEqual(t *testing.T) {
 	workDir := "/wrk"
 	dst := "dst/"
 	c, err := NewCopyOperation(
-		srcs, srcRoot, workDir, dst, validChown, false, false, pathutils.DefaultBlacklist, false)
+		srcs, srcRoot, workDir, dst, validChown, pathutils.DefaultBlacklist, false, false)
 	require.NoError(err)
 	err = fs1.AddLayerByCopyOps([]*CopyOperation{c}, w1)
 	require.NoError(err)

--- a/lib/snapshot/testutils_test.go
+++ b/lib/snapshot/testutils_test.go
@@ -237,7 +237,7 @@ func findNode(fs *MemFS, p string, followSymlink bool, depth int) (*memFSNode, e
 	return nil, os.ErrNotExist
 }
 
-func writeTarHelper(srcRoot string, w *tar.Writer) error {
+func writeTarHelper(m *memFile, srcRoot string, w *tar.Writer) error {
 	return filepath.Walk(srcRoot, func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -247,10 +247,6 @@ func writeTarHelper(srcRoot string, w *tar.Writer) error {
 		}
 		h, err := tar.FileInfoHeader(fi, "")
 		if err != nil {
-			return err
-		}
-
-		if h.Name, err = filepath.Rel(srcRoot, p); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This reverts commit f4c2bf03531ef413cf2a129e909858cb9b4409bb. ( #309 )

It turns out #309 doesn't cover the cases when dockerfiles doesn't contain RUN.

ref #298 