### PR TITLE
fix the bug of deleting file from disk

### DIFF
--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -229,7 +229,7 @@ func (fs *MemFS) UpdateFromTarReader(r *tar.Reader, untar bool) error {
 				return fmt.Errorf("untar one item %s: %s", path, err)
 			}
 		}
-		if err := fs.maybeAddToLayer(l, "", pathutils.AbsPath(hdr.Name), hdr, false); err != nil {
+		if err := fs.maybeAddToLayer(l, pathutils.AbsPath(hdr.Name), pathutils.AbsPath(hdr.Name), hdr, false); err != nil {
 			return fmt.Errorf("add hdr from tar to layer: %s", err)
 		}
 	}

--- a/lib/snapshot/mem_fs.go
+++ b/lib/snapshot/mem_fs.go
@@ -215,7 +215,7 @@ func (fs *MemFS) UpdateFromTarReader(r *tar.Reader, untar bool) error {
 					return fmt.Errorf("untar one item %s: %s", path, err)
 				}
 			}
-			if err := fs.maybeAddToLayer(l, "", pathutils.AbsPath(hdr.Name), hdr, false); err != nil {
+			if err := fs.maybeAddToLayer(l, pathutils.AbsPath(hdr.Name), pathutils.AbsPath(hdr.Name), hdr, false); err != nil {
 				return fmt.Errorf("add hdr from tar to layer: %s", err)
 			}
 		}

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -5,7 +5,6 @@ import utils
 
 import image
 
-
 def test_build_simple(registry1, registry2, storage_dir):
     new_image = utils.new_image_name()
     replica_image = utils.new_image_name()
@@ -19,6 +18,16 @@ def test_build_simple(registry1, registry2, storage_dir):
     code, err = utils.docker_run_image(registry1.addr, new_image)
     assert code == 0, err
     code, err = utils.docker_run_image(registry2.addr, replica_image)
+    assert code == 0, err
+
+
+def test_build_remove(registry1, storage_dir):
+    new_image = utils.new_image_name()
+    context_dir = os.path.join(
+        os.getcwd(), 'testdata/build-context/remove')
+    utils.makisu_build_image(
+        new_image, context_dir, storage_dir, registry=registry1.addr)
+    code, err = utils.docker_run_image(registry1.addr, new_image)
     assert code == 0, err
 
 

--- a/testdata/build-context/remove/Dockerfile
+++ b/testdata/build-context/remove/Dockerfile
@@ -1,0 +1,3 @@
+FROM centos:7
+RUN rm -vf /etc/yum.repos.d/*
+ENTRYPOINT ["/bin/bash", "-c", "echo $(ls -la /etc/yum.repos.d/)"]


### PR DESCRIPTION
This will fix #310 which couldn't delete file of the base image.

Since all the `src` of memFs is `/` and the we should `dst` to find the corresponding file info.
After running the docker file provided in #310 , we could see the files under `yum.repos.d` are removed