### PR TITLE
Allow for global ARG substitution between stages

### DIFF
--- a/lib/parser/dockerfile/arg.go
+++ b/lib/parser/dockerfile/arg.go
@@ -76,6 +76,13 @@ func (d *ArgDirective) update(state *parsingState) error {
 		d.ResolvedVal = &d.DefaultVal
 	}
 	if !global {
+		// If no value is provided to this arg, we try to replace it using the global scope
+		// (see the testdata/build-context/global-arg/Dockerfile)
+		if val, ok := state.globalArgs[d.Name]; ok {
+			vars[d.Name] = val
+			d.ResolvedVal = &val
+		}
+
 		return state.addToCurrStage(d)
 	}
 	return nil

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -287,3 +287,15 @@ def test_build_entrypoint(registry1, storage_dir):
         new_image, context_dir, storage_dir, registry=registry1.addr)
     code, err = utils.docker_run_image(registry1.addr, new_image)
     assert code == 0, err
+
+def test_build_global_arg(registry1, storage_dir):
+    new_image = utils.new_image_name()
+    context_dir = os.path.join(
+        os.getcwd(), 'testdata/build-context/global-arg')
+    docker_build_args = [
+        "version_default=v2",
+    ]
+    utils.makisu_build_image(
+        new_image, context_dir, storage_dir, registry=registry1.addr)
+    code, err = utils.docker_run_image(registry1.addr, new_image)
+    assert code == 0, err

--- a/test/python/test_build.py
+++ b/test/python/test_build.py
@@ -296,6 +296,7 @@ def test_build_global_arg(registry1, storage_dir):
         "version_default=v2",
     ]
     utils.makisu_build_image(
-        new_image, context_dir, storage_dir, registry=registry1.addr)
+        new_image, context_dir, storage_dir,
+        registry=registry1.addr, docker_args=docker_build_args)
     code, err = utils.docker_run_image(registry1.addr, new_image)
     assert code == 0, err

--- a/testdata/build-context/global-arg/Dockerfile
+++ b/testdata/build-context/global-arg/Dockerfile
@@ -1,0 +1,11 @@
+ARG version_default=v1
+
+FROM alpine:latest as base1
+ARG version_default
+ENV version=$version_default
+
+FROM alpine:latest as base2
+ARG version_default
+ENV version2=$version_default
+
+ENTRYPOINT if [ -z "$version" -a "$version2" = "v2" ]; then echo "This is correct"; exit 0; else exit 1; fi


### PR DESCRIPTION
See: https://github.com/moby/moby/issues/37345#issuecomment-400245466

While doing this I saw that the entrypoint on the image is different than docker (from Dockerfile of testdata/build-context/global-arg/Dockerfile):  
Docker:  
`if [ -z \"$version\" -a \"$version2\" = \"v2\" ]; then echo \"This is correct\"; exit 0; else exit 1; fi`
Makisu:
`if [ -z \"$version\" -a \"v2\" = \"v2\" ] ; then echo \"This is correct\" ; exit 0 ; else exit 1 ; fi`

Makisu should not do substitution in the `CMD` and `ENTRYPOINT` directive (as seen in the list here: https://docs.docker.com/engine/reference/builder/#environment-replacement)