### PR TITLE
Add tmp directory to DefaultBlacklist

### DIFF
--- a/lib/pathutils/const.go
+++ b/lib/pathutils/const.go
@@ -22,6 +22,7 @@ var (
 		// Found through experiments.
 		"/.dockerinit",
 		"/dev",
+		"/tmp",
 	}, dockerBlacklist...)
 
 	dockerBlacklist = []string{


### PR DESCRIPTION
tmp directory is being scanned in Makisu and it's included in the final image. This will include unwanted temporary files in the final image
This behaviour will not be noticed in mutlistage docker builds since we copy specific files/directories between stages, it will only be noticed in single-stage builds.
This can be considered as a breaking change if users are relying on /tmp directory somehow.