### PR TITLE
Add BackoffMax config to registry config

### DIFF
--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -46,13 +46,13 @@ type RepositoryMap map[string]Config
 
 // Config contains docker registry client configuration.
 type Config struct {
-	Concurrency   int           `yaml:"concurrency" json:"concurrency"`
-	Timeout       time.Duration `yaml:"timeout" json:"timeout"`
-	Retries       int           `yaml:"retries" json:"retries"`
-	RetryInterval time.Duration `yaml:"retry_interval" json:"retry_interval"`
-	RetryBackoff  float64       `yaml:"retry_backoff" json:"retry_backoff"`
-	BackoffMax    time.Duration `yaml:"backoff_max" json:"backoff_max"`
-	PushRate      float64       `yaml:"push_rate" json:"push_rate"`
+	Concurrency     int           `yaml:"concurrency" json:"concurrency"`
+	Timeout         time.Duration `yaml:"timeout" json:"timeout"`
+	Retries         int           `yaml:"retries" json:"retries"`
+	RetryInterval   time.Duration `yaml:"retry_interval" json:"retry_interval"`
+	RetryBackoff    float64       `yaml:"retry_backoff" json:"retry_backoff"`
+	RetryBackoffMax time.Duration `yaml:"retry_backoff_max" json:"retry_backoff_max"`
+	PushRate        float64       `yaml:"push_rate" json:"push_rate"`
 	// If not specify, a default chunk size will be used.
 	// Set it to -1 to turn off chunk upload.
 	// NOTE: gcr and ecr do not support chunked upload.
@@ -77,8 +77,8 @@ func (c Config) applyDefaults() Config {
 	if c.RetryBackoff == 0 {
 		c.RetryBackoff = 2
 	}
-	if c.BackoffMax == 0 {
-		c.BackoffMax = 30 * time.Second
+	if c.RetryBackoffMax == 0 {
+		c.RetryBackoffMax = 30 * time.Second
 	}
 	if c.PushRate == 0 {
 		c.PushRate = 100 * 1024 * 1024 // 100 MB/s
@@ -95,7 +95,7 @@ func (c *Config) sendRetry() httputil.SendOption {
 		httputil.RetryMax(c.Retries),
 		httputil.RetryInterval(c.RetryInterval),
 		httputil.RetryBackoff(c.RetryBackoff),
-		httputil.RetryBackoffMax(c.BackoffMax))
+		httputil.RetryBackoffMax(c.RetryBackoffMax))
 }
 
 // UpdateGlobalConfig updates the global registry config given either:

--- a/lib/registry/config.go
+++ b/lib/registry/config.go
@@ -51,6 +51,7 @@ type Config struct {
 	Retries       int           `yaml:"retries" json:"retries"`
 	RetryInterval time.Duration `yaml:"retry_interval" json:"retry_interval"`
 	RetryBackoff  float64       `yaml:"retry_backoff" json:"retry_backoff"`
+	BackoffMax    time.Duration `yaml:"backoff_max" json:"backoff_max"`
 	PushRate      float64       `yaml:"push_rate" json:"push_rate"`
 	// If not specify, a default chunk size will be used.
 	// Set it to -1 to turn off chunk upload.
@@ -76,6 +77,9 @@ func (c Config) applyDefaults() Config {
 	if c.RetryBackoff == 0 {
 		c.RetryBackoff = 2
 	}
+	if c.BackoffMax == 0 {
+		c.BackoffMax = 30 * time.Second
+	}
 	if c.PushRate == 0 {
 		c.PushRate = 100 * 1024 * 1024 // 100 MB/s
 	}
@@ -90,7 +94,8 @@ func (c *Config) sendRetry() httputil.SendOption {
 	return httputil.SendRetry(
 		httputil.RetryMax(c.Retries),
 		httputil.RetryInterval(c.RetryInterval),
-		httputil.RetryBackoff(c.RetryBackoff))
+		httputil.RetryBackoff(c.RetryBackoff),
+		httputil.RetryBackoffMax(c.BackoffMax))
 }
 
 // UpdateGlobalConfig updates the global registry config given either:


### PR DESCRIPTION
Make it possible to set backoff max value through the config file.
The config file is passed using `registry-config` flag. It's backward compatible and if the user didn't pass the value it will fallback to the default `30 sec`.
