### PR TITLE
Rework on registry push retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/aws/aws-sdk-go v1.30.1 // indirect
 	github.com/awslabs/amazon-ecr-credential-helper v0.4.0
 	github.com/axw/gocov v0.0.0-20170322000131-3a69a0d2a4ef
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/client9/misspell v0.3.4
 	github.com/docker/distribution v2.7.0+incompatible
 	github.com/docker/docker-credential-helpers v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,9 @@ github.com/axw/gocov v0.0.0-20170322000131-3a69a0d2a4ef h1:kh7Fi8sfEY7aCl42VEEvG
 github.com/axw/gocov v0.0.0-20170322000131-3a69a0d2a4ef/go.mod h1:pc6XrbIn8RLeVSNzXCZKXNst+RTE5Ju/nySYl1Wc0B4=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/cenkalti/backoff v1.1.0 h1:QnvVp8ikKCDWOsFheytRCoYWYPO/ObCTBGxT19Hc+yE=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/client9/misspell v0.3.4 h1:ta993UF76GwbvJcIo3Y68y/M3WxlpEHPWIGDkJYwzJI=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=

--- a/lib/registry/client.go
+++ b/lib/registry/client.go
@@ -363,7 +363,7 @@ func (c DockerRegistryClient) pullLayerHelper(
 
 // PushLayer pushes the image layer to the registry.
 func (c DockerRegistryClient) PushLayer(layerDigest image.Digest) error {
-	return c.pushLayerWithBackoff(layerDigest, true)
+	return c.pushLayerWithBackoff(layerDigest, false)
 }
 
 // PushImageConfig pushes image config blob to the registry.

--- a/lib/registry/client_test.go
+++ b/lib/registry/client_test.go
@@ -152,3 +152,14 @@ func TestPushImage(t *testing.T) {
 	require.NoError(err)
 	require.NoError(p.Push(testutil.SampleImageTag))
 }
+
+func TestPushLayerRetry(t *testing.T) {
+	require := require.New(t)
+	ctx, cleanup := context.BuildContextFixtureWithSampleImage()
+	defer cleanup()
+
+	p, err := PushClientFixture(ctx)
+	require.NoError(err)
+	p.config.Retries = 1
+	require.EqualError(p.PushLayer(image.NewEmptyDigest()), "push layer content : get layer file stat: file does not exist; push layer content : get layer file stat: file does not exist")
+}

--- a/lib/registry/push_fixture.go
+++ b/lib/registry/push_fixture.go
@@ -92,6 +92,7 @@ func (t pushTransportFixture) RoundTrip(r *http.Request) (*http.Response, error)
 	if !found {
 		return &http.Response{
 			StatusCode: http.StatusNotFound,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte{})),
 			Header:     make(http.Header),
 		}, nil
 	}

--- a/lib/utils/httputil/httputil_test.go
+++ b/lib/utils/httputil/httputil_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cenkalti/backoff"
 	"github.com/golang/mock/gomock"
 	"github.com/pressly/chi"
 	"github.com/stretchr/testify/require"
@@ -69,17 +70,15 @@ func TestSendRetry(t *testing.T) {
 
 	transport := mockhttp.NewMockRoundTripper(ctrl)
 
-	for _, status := range []int{503, 500, 200} {
+	for _, status := range []int{503, 502, 200} {
 		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(status), nil)
 	}
 
-	start := time.Now()
 	_, err := Get(
 		_testURL,
-		SendRetry(RetryMax(5), RetryInterval(200*time.Millisecond)),
+		SendRetry(),
 		SendTransport(transport))
 	require.NoError(err)
-	require.InDelta(400*time.Millisecond, time.Since(start), float64(50*time.Millisecond))
 }
 
 func TestSendRetryOnTransportErrors(t *testing.T) {
@@ -92,16 +91,14 @@ func TestSendRetryOnTransportErrors(t *testing.T) {
 
 	transport.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("some network error")).Times(3)
 
-	start := time.Now()
 	_, err := Get(
 		_testURL,
-		SendRetry(RetryMax(3), RetryInterval(200*time.Millisecond)),
+		SendRetry(),
 		SendTransport(transport))
 	require.Error(err)
-	require.InDelta(400*time.Millisecond, time.Since(start), float64(50*time.Millisecond))
 }
 
-func TestSendRetryOn5XX(t *testing.T) {
+func TestSendRetryWithCodes(t *testing.T) {
 	require := require.New(t)
 
 	ctrl := gomock.NewController(t)
@@ -109,60 +106,23 @@ func TestSendRetryOn5XX(t *testing.T) {
 
 	transport := mockhttp.NewMockRoundTripper(ctrl)
 
-	transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(503), nil).Times(3)
+	gomock.InOrder(
+		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(400), nil),
+		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(503), nil),
+		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(404), nil),
+		transport.EXPECT().RoundTrip(gomock.Any()).Return(newResponse(500), nil), // Non-retryable.
+	)
 
-	start := time.Now()
 	_, err := Get(
 		_testURL,
-		SendRetry(RetryMax(3), RetryInterval(200*time.Millisecond)),
-		SendTransport(transport))
-	require.Error(err)
-	require.Equal(503, err.(StatusError).Status)
-	require.InDelta(400*time.Millisecond, time.Since(start), float64(50*time.Millisecond))
-}
-
-func TestSendRetryBackoff(t *testing.T) {
-	require := require.New(t)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	transport := mockhttp.NewMockRoundTripper(ctrl)
-
-	transport.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("some error")).Times(4)
-
-	start := time.Now()
-	_, err := Get(
-		_testURL,
-		// Intervals should be 200, 300, 450.
-		SendRetry(RetryMax(4), RetryInterval(200*time.Millisecond), RetryBackoff(1.5)),
-		SendTransport(transport))
-	require.Error(err)
-	require.InDelta(950*time.Millisecond, time.Since(start), float64(50*time.Millisecond))
-}
-
-func TestSendRetryBackoffMax(t *testing.T) {
-	require := require.New(t)
-
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	transport := mockhttp.NewMockRoundTripper(ctrl)
-
-	transport.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("some error")).Times(4)
-
-	start := time.Now()
-	_, err := Get(
-		_testURL,
-		// Interval should be 200, 300, 300 (max).
 		SendRetry(
-			RetryMax(4),
-			RetryInterval(200*time.Millisecond),
-			RetryBackoff(1.5),
-			RetryBackoffMax(300*time.Millisecond)),
+			RetryBackoff(backoff.WithMaxRetries(
+				backoff.NewConstantBackOff(200*time.Millisecond),
+				10)),
+			RetryCodes(400, 404)),
 		SendTransport(transport))
 	require.Error(err)
-	require.InDelta(800*time.Millisecond, time.Since(start), float64(50*time.Millisecond))
+	require.Equal(500, err.(StatusError).Status) // Last code returned.
 }
 
 func TestStatusChecking(t *testing.T) {

--- a/lib/utils/httputil/httputil_test.go
+++ b/lib/utils/httputil/httputil_test.go
@@ -89,7 +89,7 @@ func TestSendRetryOnTransportErrors(t *testing.T) {
 
 	transport := mockhttp.NewMockRoundTripper(ctrl)
 
-	transport.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("some network error")).Times(3)
+	transport.EXPECT().RoundTrip(gomock.Any()).Return(nil, errors.New("some network error")).Times(4)
 
 	_, err := Get(
 		_testURL,


### PR DESCRIPTION
A few changes in this diff:
1. Switch to use `github.com/cenkalti/backoff` for backoff logic.
2. By default, retry only on specific http status code (referring to [registry's doc](https://github.com/docker/distribution/blob/53e18a9d9bfeb2b2b210cde34f10a6938b81f852/docs/spec/api.md#errors-1) on handling specific error codes).
3. Since we use stream upload when pushing a layer, if a non-retryable error happens, we should try restart pushing the layer from the beginning.