### PR TITLE
Pull command image name parsing and registry config support

### DIFF
--- a/bin/makisu/cmd/pull.go
+++ b/bin/makisu/cmd/pull.go
@@ -22,6 +22,7 @@ type pullCmd struct {
 
 	cacerts        string
 	extract        string
+	registryConfig string
 }
 
 func getPullCmd() *pullCmd {
@@ -43,6 +44,7 @@ func getPullCmd() *pullCmd {
 	}
 
 	pullCmd.PersistentFlags().StringVar(&pullCmd.cacerts, "cacerts", "/etc/ssl/certs", "The location of the CA certs to use for TLS authentication with the registry.")
+	pullCmd.PersistentFlags().StringVar(&pullCmd.registryConfig, "registry-config", "", "Set build-time variables")
 
 	pullCmd.PersistentFlags().StringVar(&pullCmd.extract, "extract", "", "The destination of the rootfs that we will untar the image to.")
 	return pullCmd
@@ -52,6 +54,10 @@ func (cmd *pullCmd) Pull(imageName string) {
 	store, err := storage.NewImageStore("/tmp/makisu-storage")
 	if err != nil {
 		panic(err)
+	}
+
+	if err := initRegistryConfig(cmd.registryConfig); err != nil {
+		panic(fmt.Errorf("failed to initialize registry configuration: %s", err))
 	}
 
 	pullImage, err := image.ParseNameForPull(imageName)


### PR DESCRIPTION
The pull command appears to be unable to pull from docker.io when it gets a 401 UNAUTHORIZED:

```
$ docker run  gcr.io/uber-container-tools/makisu:latest pull --cacerts=/makisu-internal/certs/ busybox
{"level":"info","ts":1610039682.90314,"msg":"* Started pulling image index.docker.io/busybox:latest"}
panic: pull manifest: http send error: GET https://index.docker.io/v2/busybox/manifests/latest 401: {"errors":[{"code":"UNAUTHORIZED","message":"authentication required","detail":[{"Type":"repository","Class":"","Name":"busybox","Action":"pull"}]}]}


goroutine 1 [running]:
github.com/uber/makisu/bin/makisu/cmd.(*pullCmd).Pull(0xc000382550, 0x7fff6b1bcf79, 0x7)
	/workspace/github.com/uber/makisu/bin/makisu/cmd/pull.go:68 +0x33d
github.com/uber/makisu/bin/makisu/cmd.getPullCmd.func2(0xc000468000, 0xc0003697a0, 0x1, 0x2)
	/workspace/github.com/uber/makisu/bin/makisu/cmd/pull.go:44 +0x4a
github.com/spf13/cobra.(*Command).execute(0xc000468000, 0xc000369700, 0x2, 0x2, 0xc000468000, 0xc000369700)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:766 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0xc0003b5680, 0xc000243f60, 0x1, 0x1)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:852 +0x2ec
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v0.0.3/command.go:800
github.com/uber/makisu/bin/makisu/cmd.Execute()
	/workspace/github.com/uber/makisu/bin/makisu/cmd/root.go:79 +0x15a
main.main()
	/workspace/github.com/uber/makisu/bin/makisu/main.go:22 +0x20
```

This commit changes it's pull behavior to be more like `FromStep` by removing the explicit `DefaultDockerHubConfiguration` configuration.

The `--registry` and `--tag` arguments are removed, instead the image name is parsed with `ParseNameForPull`. This is a breaking change. It would be possible to change this to preserve backwards compatibility still use `--registry` and `--tag` if present.

The pull command did not allow providing a registry config. This PR adds a `--registry-config` argument in the same way as the build command.