### PR TITLE
Forgive the case when a whiteout file trying to cover nonexistent path

### DIFF
--- a/lib/snapshot/mem_layer.go
+++ b/lib/snapshot/mem_layer.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/uber/makisu/lib/log"
 	"github.com/uber/makisu/lib/pathutils"
 	"github.com/uber/makisu/lib/tario"
 )
@@ -114,7 +115,9 @@ func (f *whiteoutMemFile) updateMemFS(node *memFSNode) error {
 			if i != len(parts)-1 {
 				return fmt.Errorf("missing intermediate dir %s in %s", part, f.del)
 			}
-			return fmt.Errorf("whiteout nonexistent path %s", f.del)
+			// This could happen to files that's cleaned up in the background, like
+			// python package's dist-info file.
+			log.Warnf("Trying to whiteout nonexistent path: %s", f.del)
 		}
 	}
 	return nil

--- a/lib/snapshot/mem_layer.go
+++ b/lib/snapshot/mem_layer.go
@@ -116,7 +116,7 @@ func (f *whiteoutMemFile) updateMemFS(node *memFSNode) error {
 				return fmt.Errorf("missing intermediate dir %s in %s", part, f.del)
 			}
 			// This could happen to files that's cleaned up in the background, like
-			// python package's dist-info file.
+			// python package's .dist-info or .pth file.
 			log.Warnf("Trying to whiteout nonexistent path: %s", f.del)
 		}
 	}


### PR DESCRIPTION
This error happens sometimes with python package's .dist-info or .pth files. For example, installing aiohttp package in a conda environment, then when applying cache of layer, this error message happens often:
```
[error] 2021-03-09 17:36:12.468002: failed to execute build plan: execute stage: build stage 0: build node: apply cache: untar reader: add hdr from tar to layer: update memfs with file /home/ray/anaconda3/lib/python3.7/site-packages/.wh.aiohttp-3.7.4.dist-info: whiteout nonexistent path /home/ray/anaconda3/lib/python3.7/site-packages/aiohttp-3.7.4.dist-info
```
Those files were probably created or removed asynchronously.
It doesn't hurt to ignore this case; Change to a warning message instead.