### PR TITLE
Forgive the case when a whiteout file trying to cover nonexistent path 

### DIFF
--- a/lib/snapshot/mem_fs_test.go
+++ b/lib/snapshot/mem_fs_test.go
@@ -303,7 +303,7 @@ func TestUpdateMemFS(t *testing.T) {
 		require.Equal(os.ErrNotExist, err)
 	})
 
-	t.Run("WhiteoutNonexistentCausesError", func(t *testing.T) {
+	t.Run("WhiteoutNonexistentNotCausingError", func(t *testing.T) {
 		require := require.New(t)
 
 		tmpRoot, err := ioutil.TempDir("/tmp", "makisu-test")
@@ -333,7 +333,7 @@ func TestUpdateMemFS(t *testing.T) {
 		require.NoError(addDirectoryToLayer(l2, tmpRoot, dst21, 0755))
 		dst22 := "/test11/.wh.test13"
 		require.NoError(addDirectoryToLayer(l2, tmpRoot, dst22, 0755))
-		require.Error(fs.merge(l2))
+		require.NoError(fs.merge(l2))
 	})
 }
 

--- a/lib/snapshot/mem_layer.go
+++ b/lib/snapshot/mem_layer.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/uber/makisu/lib/log"
 	"github.com/uber/makisu/lib/pathutils"
 	"github.com/uber/makisu/lib/tario"
 )
@@ -114,7 +115,9 @@ func (f *whiteoutMemFile) updateMemFS(node *memFSNode) error {
 			if i != len(parts)-1 {
 				return fmt.Errorf("missing intermediate dir %s in %s", part, f.del)
 			}
-			return fmt.Errorf("whiteout nonexistent path %s", f.del)
+			// This could happen to files that's cleaned up in the background, like
+			// python package's .dist-info or .pth file.
+			log.Warnf("Trying to whiteout nonexistent path: %s", f.del)
 		}
 	}
 	return nil


### PR DESCRIPTION
Retry #358 

This error happens sometimes with python package's .dist-info or .pth files. For example, installing aiohttp package in a conda environment, then when applying cache of layer, this error message happens often:

[error] 2021-03-09 17:36:12.468002: failed to execute build plan: execute stage: build stage 0: build node: apply cache: untar reader: add hdr from tar to layer: update memfs with file /home/ray/anaconda3/lib/python3.7/site-packages/.wh.aiohttp-3.7.4.dist-info: whiteout nonexistent path /home/ray/anaconda3/lib/python3.7/site-packages/aiohttp-3.7.4.dist-info
Those files were probably created or removed asynchronously.
It doesn't hurt to ignore this case; Change to a warning message instead.